### PR TITLE
Add cache manager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,11 @@ fix: $(POT) $(PO) $(APP).yml
 	go mod tidy
 	([ -d vendor ] && go mod vendor) || true
 	echo $(UI_SOURCES) | xargs -n1 gtk-builder-tool simplify --replace
-	dos2unix -q po/LINGUAS po/POTFILES po/appdata.its $(POT) $(PO)
+	(find data -name '*.in' && \
+	 printf '%s\n' $(UI_SOURCES) && \
+	 grep -E -l '[^A-Za-z0-9]l\(' $(GO_SOURCES)\
+	) | sort >po/POTFILES
+	dos2unix -q po/LINGUAS po/appdata.its $(POT) $(PO)
 	for lang in $(LINGUAS); do \
 		msgmerge -U --backup=none "po/$$lang.po" $(POT); \
 	done

--- a/data/com.github.rkoesters.xkcd-gtk.desktop.in
+++ b/data/com.github.rkoesters.xkcd-gtk.desktop.in
@@ -18,13 +18,13 @@ Actions=new-window;show-shortcuts;show-about;
 Name=New window
 Exec=com.github.rkoesters.xkcd-gtk
 
-[Desktop Action show-shortcuts]
-Name=Keyboard shortcuts
-Exec=gdbus call --session --dest=com.github.rkoesters.xkcd-gtk --object-path=/com/github/rkoesters/xkcd_gtk --method=org.freedesktop.Application.ActivateAction show-shortcuts [] {}
-
 [Desktop Action show-cache]
 Name=Cache manager
 Exec=gdbus call --session --dest=com.github.rkoesters.xkcd-gtk --object-path=/com/github/rkoesters/xkcd_gtk --method=org.freedesktop.Application.ActivateAction show-cache [] {}
+
+[Desktop Action show-shortcuts]
+Name=Keyboard shortcuts
+Exec=gdbus call --session --dest=com.github.rkoesters.xkcd-gtk --object-path=/com/github/rkoesters/xkcd_gtk --method=org.freedesktop.Application.ActivateAction show-shortcuts [] {}
 
 [Desktop Action show-about]
 Name=About

--- a/data/com.github.rkoesters.xkcd-gtk.desktop.in
+++ b/data/com.github.rkoesters.xkcd-gtk.desktop.in
@@ -12,7 +12,7 @@ StartupNotify=true
 Terminal=false
 Categories=Network;Amusement;Viewer;GTK;
 Keywords=webcomic;romance;sarcasm;math;language;
-Actions=new-window;show-shortcuts;show-about;
+Actions=new-window;show-cache;show-shortcuts;show-about;
 
 [Desktop Action new-window]
 Name=New window

--- a/data/com.github.rkoesters.xkcd-gtk.desktop.in
+++ b/data/com.github.rkoesters.xkcd-gtk.desktop.in
@@ -22,6 +22,10 @@ Exec=com.github.rkoesters.xkcd-gtk
 Name=Keyboard shortcuts
 Exec=gdbus call --session --dest=com.github.rkoesters.xkcd-gtk --object-path=/com/github/rkoesters/xkcd_gtk --method=org.freedesktop.Application.ActivateAction show-shortcuts [] {}
 
+[Desktop Action show-cache]
+Name=Cache manager
+Exec=gdbus call --session --dest=com.github.rkoesters.xkcd-gtk --object-path=/com/github/rkoesters/xkcd_gtk --method=org.freedesktop.Application.ActivateAction show-cache [] {}
+
 [Desktop Action show-about]
 Name=About
 Exec=gdbus call --session --dest=com.github.rkoesters.xkcd-gtk --object-path=/com/github/rkoesters/xkcd_gtk --method=org.freedesktop.Application.ActivateAction show-about [] {}

--- a/internal/app/application.go
+++ b/internal/app/application.go
@@ -164,7 +164,7 @@ func (app *Application) SetupCache() {
 
 	// Asynchronously fill the comic metadata cache and search index.
 	log.Debug("calling cache.DownloadAllComicMetadata()")
-	cache.DownloadAllComicMetadata(app.CacheWindow)
+	cache.DownloadAllComicMetadata(app.CacheWindowVRW)
 }
 
 // CloseCache closes the search index and comic cache.
@@ -395,7 +395,13 @@ func (app *Application) ShowCache() {
 	app.cacheWindow.Present()
 }
 
-func (app *Application) CacheWindow() cache.ViewRefresher {
+func (app *Application) CacheWindowVR() cache.ViewRefresher {
+	app.cacheWindowMutex.RLock()
+	defer app.cacheWindowMutex.RUnlock()
+	return app.cacheWindow
+}
+
+func (app *Application) CacheWindowVRW() cache.ViewRefreshWither {
 	app.cacheWindowMutex.RLock()
 	defer app.cacheWindowMutex.RUnlock()
 	return app.cacheWindow

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -160,27 +160,6 @@ func Close() error {
 	return err
 }
 
-// ViewRefresher provides methods for refreshing the view of cache statistics.
-// All methods must silently accept a nil receiver.
-type ViewRefresher interface {
-	RefreshMetadata()
-	RefreshMetadataWith(Stat)
-	RefreshImages()
-	RefreshImagesWith(Stat)
-}
-
-// ViewRefresherGetter returns a ViewRefresher. Useful for lazily passing the
-// ViewRefresher as an argument.
-type ViewRefresherGetter func() ViewRefresher
-
-type nullRefresher struct{}
-
-func newNullRefresher() ViewRefresher              { return nullRefresher{} }
-func (r nullRefresher) RefreshMetadata()           {}
-func (r nullRefresher) RefreshMetadataWith(_ Stat) {}
-func (r nullRefresher) RefreshImages()             {}
-func (r nullRefresher) RefreshImagesWith(_ Stat)   {}
-
 // DownloadAllComicMetadata asynchronously fills the comic metadata cache and
 // search index via the internet. Status can be checked with Stat().
 func DownloadAllComicMetadata(cacheWindow ViewRefresherGetter) {

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -414,7 +414,7 @@ func DownloadAllComicImages(cacheWindow ViewRefresherGetter) {
 	for i := 1; i <= newest.Num; i++ {
 		_, err = os.Stat(ComicImagePath(i))
 		if os.IsNotExist(err) {
-			DownloadComicImage(i, newNullRefresher)
+			DownloadComicImage(i, func() ViewRefresher { return nilRefresher })
 		}
 
 		cacheWindow().RefreshImagesWith(Stat{

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -162,7 +162,7 @@ func Close() error {
 
 // DownloadAllComicMetadata asynchronously fills the comic metadata cache and
 // search index via the internet. Status can be checked with Stat().
-func DownloadAllComicMetadata(cacheWindow ViewRefresherGetter) {
+func DownloadAllComicMetadata(cacheWindow ViewRefreshWitherGetter) {
 	// Make sure all comic metadata is cached and indexed.
 	go func() {
 		newest, err := NewestComicInfoFromInternet()
@@ -405,7 +405,7 @@ func DownloadComicImage(n int, cacheWindow ViewRefresherGetter) error {
 
 // DownloadAllComicImages tries to add all comic images to our local cache. If
 // successful, the images can be found at the path returned by ComicImagePath.
-func DownloadAllComicImages(cacheWindow ViewRefresherGetter) {
+func DownloadAllComicImages(cacheWindow ViewRefreshWitherGetter) {
 	newest, err := NewestComicInfoFromCache()
 	if err != nil {
 		log.Print(err)

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -388,7 +388,7 @@ func DownloadComicImage(n int, cacheWindow ViewRefresher) error {
 		return ErrOffline
 	}
 
-	defer cacheWindow.RefreshImages()
+	defer func() { go cacheWindow.RefreshImages() }()
 
 	log.Debugf("DownloadComicImage(%v) start", n)
 	defer log.Debugf("DownloadComicImage(%v) end", n)

--- a/internal/cache/refresher.go
+++ b/internal/cache/refresher.go
@@ -1,0 +1,22 @@
+package cache
+
+// ViewRefresher provides methods for refreshing the view of cache statistics.
+// All methods must silently accept a nil receiver.
+type ViewRefresher interface {
+	RefreshMetadata()
+	RefreshMetadataWith(Stat)
+	RefreshImages()
+	RefreshImagesWith(Stat)
+}
+
+// ViewRefresherGetter returns a ViewRefresher. Useful for lazily passing the
+// ViewRefresher as an argument.
+type ViewRefresherGetter func() ViewRefresher
+
+type nullRefresher struct{}
+
+func newNullRefresher() ViewRefresher              { return nullRefresher{} }
+func (r nullRefresher) RefreshMetadata()           {}
+func (r nullRefresher) RefreshMetadataWith(_ Stat) {}
+func (r nullRefresher) RefreshImages()             {}
+func (r nullRefresher) RefreshImagesWith(_ Stat)   {}

--- a/internal/cache/refresher.go
+++ b/internal/cache/refresher.go
@@ -11,7 +11,9 @@ type ViewRefreshWither interface {
 // All methods must silently accept a nil receiver.
 type ViewRefresher interface {
 	ViewRefreshWither
+	// RefreshMetadata queries StatMetadata then calls RefreshMetadataWith.
 	RefreshMetadata()
+	// RefreshImages queries StatImages then calls RefreshImagesWith.
 	RefreshImages()
 }
 

--- a/internal/cache/refresher.go
+++ b/internal/cache/refresher.go
@@ -1,17 +1,27 @@
 package cache
 
-// ViewRefresher provides methods for refreshing the view of cache statistics.
+// ViewRefreshWither provides methods for refreshing a view of cache statistics
+// with the provided stat. All methods must silently accept a nil receiver.
+type ViewRefreshWither interface {
+	RefreshMetadataWith(Stat)
+	RefreshImagesWith(Stat)
+}
+
+// ViewRefresher provides methods for refreshing a view of cache statistics.
 // All methods must silently accept a nil receiver.
 type ViewRefresher interface {
+	ViewRefreshWither
 	RefreshMetadata()
-	RefreshMetadataWith(Stat)
 	RefreshImages()
-	RefreshImagesWith(Stat)
 }
 
 // ViewRefresherGetter returns a ViewRefresher. Useful for lazily passing the
 // ViewRefresher as an argument.
 type ViewRefresherGetter func() ViewRefresher
+
+// ViewRefreshWitherGetter returns a ViewRefreshWither. Useful for lazily
+// passing the ViewRefreshWither as an argument.
+type ViewRefreshWitherGetter func() ViewRefreshWither
 
 type nullRefresher struct{}
 

--- a/internal/cache/refresher.go
+++ b/internal/cache/refresher.go
@@ -15,8 +15,9 @@ type ViewRefresherGetter func() ViewRefresher
 
 type nullRefresher struct{}
 
-func newNullRefresher() ViewRefresher              { return nullRefresher{} }
-func (r nullRefresher) RefreshMetadata()           {}
-func (r nullRefresher) RefreshMetadataWith(_ Stat) {}
-func (r nullRefresher) RefreshImages()             {}
-func (r nullRefresher) RefreshImagesWith(_ Stat)   {}
+func (_ *nullRefresher) RefreshMetadata()           {}
+func (_ *nullRefresher) RefreshMetadataWith(_ Stat) {}
+func (_ *nullRefresher) RefreshImages()             {}
+func (_ *nullRefresher) RefreshImagesWith(_ Stat)   {}
+
+var nilRefresher *nullRefresher = nil

--- a/internal/cache/stat.go
+++ b/internal/cache/stat.go
@@ -1,0 +1,104 @@
+package cache
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"regexp"
+
+	bolt "go.etcd.io/bbolt"
+)
+
+var imageFileNameRegex = regexp.MustCompile("^[0-9][0-9]*$")
+
+type CacheStat struct {
+	LatestComicNumber uint
+	CachedCount       uint
+}
+
+func (cs CacheStat) Fraction() (float64, error) {
+	if cs.LatestComicNumber == 0 {
+		return 0, errors.New("division by zero")
+	}
+	return float64(cs.CachedCount) / float64(cs.LatestComicNumber), nil
+}
+
+func (cs CacheStat) String() string {
+	return fmt.Sprintln(cs.CachedCount, "/", cs.LatestComicNumber)
+}
+
+func StatMetadata() (CacheStat, error) {
+	var cs CacheStat
+	latestComic, err := NewestComicInfoFromCache()
+	if err != nil {
+		return cs, err
+	}
+	cs.LatestComicNumber = uint(latestComic.Num)
+	cs.CachedCount, err = countCachedMetadata()
+	return cs, err
+}
+
+func countCachedMetadata() (uint, error) {
+	var count uint
+
+	// We are ready to display comic #404, which is an error page rather than an
+	// image.
+	count++
+
+	err := cacheDB.View(func(tx *bolt.Tx) error {
+		var err error
+
+		bucket := tx.Bucket(comicCacheMetadataBucketName)
+		if bucket == nil {
+			return ErrLocalFailure
+		}
+
+		err = bucket.ForEach(func(_, _ []byte) error {
+			count++
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+	return count, err
+}
+
+func StatImages() (CacheStat, error) {
+	var cs CacheStat
+
+	latestComic, err := NewestComicInfoFromCache()
+	if err != nil {
+		return cs, err
+	}
+	cs.LatestComicNumber = uint(latestComic.Num)
+
+	cs.CachedCount, err = countCachedImages()
+	return cs, err
+}
+
+func countCachedImages() (uint, error) {
+	var count uint
+
+	// We are ready to display comic #404, which is an error page rather than an
+	// image.
+	count++
+
+	files, err := os.ReadDir(comicImageDirPath())
+	if err != nil {
+		return count, err
+	}
+	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+		if !imageFileNameRegex.MatchString(file.Name()) {
+			continue
+		}
+		count++
+	}
+
+	return count, nil
+}

--- a/internal/cache/stat.go
+++ b/internal/cache/stat.go
@@ -17,6 +17,10 @@ type Stat struct {
 	CachedCount       int
 }
 
+func (s Stat) Complete() bool {
+	return s.LatestComicNumber == s.CachedCount
+}
+
 func (s Stat) Fraction() (float64, error) {
 	if s.LatestComicNumber == 0 {
 		return 0, errors.New("division by zero")

--- a/internal/search/index.go
+++ b/internal/search/index.go
@@ -4,15 +4,11 @@ package search
 
 import (
 	"strconv"
-	"time"
 
 	"github.com/blevesearch/bleve/v2"
 	"github.com/blevesearch/bleve/v2/search/query"
-	"github.com/gotk3/gotk3/gdk"
-	"github.com/gotk3/gotk3/glib"
 	"github.com/gotk3/gotk3/gtk"
 	"github.com/rkoesters/xkcd"
-	"github.com/rkoesters/xkcd-gtk/internal/cache"
 	"github.com/rkoesters/xkcd-gtk/internal/log"
 	"github.com/rkoesters/xkcd-gtk/internal/paths"
 )
@@ -59,80 +55,4 @@ func Search(userQuery string) (*bleve.SearchResult, error) {
 type WindowAddRemover interface {
 	AddWindow(gtk.IWindow)
 	RemoveWindow(gtk.IWindow)
-}
-
-// Load asynchronously fills the comic metadata cache and search index via the
-// internet. It may show a loading dialog to the user.
-func Load(war WindowAddRemover) error {
-	loadingWindow, err := gtk.WindowNew(gtk.WINDOW_TOPLEVEL)
-	if err != nil {
-		return err
-	}
-	loadingWindow.SetTitle(l("Search Index Update"))
-	loadingWindow.SetTypeHint(gdk.WINDOW_TYPE_HINT_DIALOG)
-	loadingWindow.SetResizable(false)
-
-	progressBar, err := gtk.ProgressBarNew()
-	if err != nil {
-		return err
-	}
-	progressBar.SetText(l("Updating comic search index..."))
-	progressBar.SetShowText(true)
-	progressBar.SetMarginTop(24)
-	progressBar.SetMarginBottom(24)
-	progressBar.SetMarginStart(24)
-	progressBar.SetMarginEnd(24)
-	progressBar.SetSizeRequest(300, -1)
-	progressBar.SetFraction(0)
-	progressBar.Show()
-	loadingWindow.Add(progressBar)
-
-	done := make(chan struct{})
-
-	// Make sure all comic metadata is cached and indexed.
-	go func() {
-		defer func() { done <- struct{}{} }()
-
-		newest, err := cache.NewestComicInfoFromInternet()
-		if err != nil {
-			return
-		}
-		for i := 1; i <= newest.Num; i++ {
-			n := i
-			cache.ComicInfo(n)
-			glib.IdleAdd(func() {
-				progressBar.SetFraction(float64(n) / float64(newest.Num))
-			})
-		}
-	}()
-
-	// Show cache progress window.
-	go func() {
-		// Wait before showing the cache progress window. If the cache is
-		// already complete, then the caching and indexing operation will be
-		// very fast.
-		time.Sleep(2 * time.Second)
-
-		select {
-		case <-done:
-			// Already done, don't bother showing the window.
-			glib.IdleAdd(loadingWindow.Destroy)
-			return
-		default:
-			glib.IdleAdd(func() {
-				war.AddWindow(loadingWindow)
-				loadingWindow.Present()
-			})
-		}
-
-		// Wait until we are done.
-		<-done
-
-		glib.IdleAdd(func() {
-			war.RemoveWindow(loadingWindow)
-			loadingWindow.Close()
-		})
-	}()
-
-	return nil
 }

--- a/internal/search/index.go
+++ b/internal/search/index.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/blevesearch/bleve/v2"
 	"github.com/blevesearch/bleve/v2/search/query"
-	"github.com/gotk3/gotk3/gtk"
 	"github.com/rkoesters/xkcd"
 	"github.com/rkoesters/xkcd-gtk/internal/log"
 	"github.com/rkoesters/xkcd-gtk/internal/paths"
@@ -50,9 +49,4 @@ func Search(userQuery string) (*bleve.SearchResult, error) {
 	searchRequest.Size = 100
 	searchRequest.Fields = []string{"*"}
 	return index.Search(searchRequest)
-}
-
-type WindowAddRemover interface {
-	AddWindow(gtk.IWindow)
-	RemoveWindow(gtk.IWindow)
 }

--- a/internal/style/style.go
+++ b/internal/style/style.go
@@ -20,7 +20,7 @@ const (
 	PaddingComicListButton   = 8
 	PaddingPopover           = 10
 	PaddingPopoverCompact    = 8
-	PaddingPropertiesDialog  = 12
+	PaddingAuxiliaryWindow   = 12
 	PaddingUnlinkedButtonBox = 4
 )
 

--- a/internal/widget/app-menu.ui
+++ b/internal/widget/app-menu.ui
@@ -15,6 +15,12 @@
     </section>
     <section>
       <item>
+        <attribute name="label" translatable="yes">Cache manager</attribute>
+        <attribute name="action">app.show-cache</attribute>
+      </item>
+    </section>
+    <section>
+      <item>
         <attribute name="label" translatable="yes">What If?</attribute>
         <attribute name="action">app.open-what-if</attribute>
       </item>

--- a/internal/widget/app-menu.ui
+++ b/internal/widget/app-menu.ui
@@ -9,14 +9,14 @@
     </section>
     <section>
       <item>
-        <attribute name="label" translatable="yes">Toggle dark mode</attribute>
-        <attribute name="action">app.toggle-dark-mode</attribute>
+        <attribute name="label" translatable="yes">Cache manager</attribute>
+        <attribute name="action">app.show-cache</attribute>
       </item>
     </section>
     <section>
       <item>
-        <attribute name="label" translatable="yes">Cache manager</attribute>
-        <attribute name="action">app.show-cache</attribute>
+        <attribute name="label" translatable="yes">Toggle dark mode</attribute>
+        <attribute name="action">app.toggle-dark-mode</attribute>
       </item>
     </section>
     <section>

--- a/internal/widget/application-window.go
+++ b/internal/widget/application-window.go
@@ -355,7 +355,7 @@ func (win *ApplicationWindow) SetComic(n int) {
 			return
 		}
 
-		err = cache.DownloadComicImage(n, win.app.CacheWindow)
+		err = cache.DownloadComicImage(n, win.app.CacheWindowVR)
 		if err != nil {
 			log.Print("error downloading comic image: ", err)
 			// We can be sneaky if we get an error, we use SafeTitle for window

--- a/internal/widget/application-window.go
+++ b/internal/widget/application-window.go
@@ -355,7 +355,7 @@ func (win *ApplicationWindow) SetComic(n int) {
 			return
 		}
 
-		err = cache.DownloadComicImage(n, win.app.CacheWindow())
+		err = cache.DownloadComicImage(n, win.app.CacheWindow)
 		if err != nil {
 			log.Print("error downloading comic image: ", err)
 			// We can be sneaky if we get an error, we use SafeTitle for window

--- a/internal/widget/application-window.go
+++ b/internal/widget/application-window.go
@@ -355,7 +355,7 @@ func (win *ApplicationWindow) SetComic(n int) {
 			return
 		}
 
-		err = cache.DownloadComicImage(n)
+		err = cache.DownloadComicImage(n, win.app.CacheWindow())
 		if err != nil {
 			log.Print("error downloading comic image: ", err)
 			// We can be sneaky if we get an error, we use SafeTitle for window

--- a/internal/widget/application.go
+++ b/internal/widget/application.go
@@ -16,7 +16,8 @@ func AppName() string { return l("Comic Sticks") }
 type Application interface {
 	AddWindow(gtk.IWindow)
 	BookmarksList() *bookmarks.List
-	CacheWindow() cache.ViewRefresher
+	CacheWindowVR() cache.ViewRefresher
+	CacheWindowVRW() cache.ViewRefreshWither
 	ConnectDarkModeChanged(f interface{}) glib.SignalHandle
 	DarkMode() bool
 	GtkApplication() *gtk.Application

--- a/internal/widget/application.go
+++ b/internal/widget/application.go
@@ -4,6 +4,7 @@ import (
 	"github.com/gotk3/gotk3/glib"
 	"github.com/gotk3/gotk3/gtk"
 	"github.com/rkoesters/xkcd-gtk/internal/bookmarks"
+	"github.com/rkoesters/xkcd-gtk/internal/cache"
 )
 
 // AppName is the user-visible name of this application.
@@ -15,7 +16,7 @@ func AppName() string { return l("Comic Sticks") }
 type Application interface {
 	AddWindow(gtk.IWindow)
 	BookmarksList() *bookmarks.List
-	CacheWindow() *CacheWindow
+	CacheWindow() cache.ViewRefresher
 	ConnectDarkModeChanged(f interface{}) glib.SignalHandle
 	DarkMode() bool
 	GtkApplication() *gtk.Application

--- a/internal/widget/application.go
+++ b/internal/widget/application.go
@@ -15,11 +15,13 @@ func AppName() string { return l("Comic Sticks") }
 type Application interface {
 	AddWindow(gtk.IWindow)
 	BookmarksList() *bookmarks.List
+	CacheWindow() *CacheWindow
 	ConnectDarkModeChanged(f interface{}) glib.SignalHandle
 	DarkMode() bool
 	GtkApplication() *gtk.Application
 	GtkTheme() (string, error)
-	PrefersAppMenu() bool
-	SetDarkMode(bool)
 	OpenURL(string) error
+	PrefersAppMenu() bool
+	RemoveWindow(gtk.IWindow)
+	SetDarkMode(bool)
 }

--- a/internal/widget/cache-window.go
+++ b/internal/widget/cache-window.go
@@ -92,7 +92,7 @@ func NewCacheWindow(app Application) (*CacheWindow, error) {
 	registerAction("download-all-images", func() {
 		cw.actions["download-all-images"].SetEnabled(false)
 		go func() {
-			cache.DownloadAllComicImages(cw)
+			cache.DownloadAllComicImages(func() cache.ViewRefresher { return cw })
 			b := cw.actions["download-all-images"]
 			glib.IdleAdd(func() {
 				b.SetEnabled(true)

--- a/internal/widget/cache-window.go
+++ b/internal/widget/cache-window.go
@@ -106,8 +106,11 @@ func NewCacheWindow(app Application) (*CacheWindow, error) {
 
 func (cw *CacheWindow) Dispose() {
 	cw.ApplicationWindow = nil
+	cw.actions = nil
+	cw.box = nil
 	cw.metadataLevelBar = nil
 	cw.imageLevelBar = nil
+	cw.downloadAllImagesButton = nil
 }
 
 func (cw *CacheWindow) Present() {

--- a/internal/widget/cache-window.go
+++ b/internal/widget/cache-window.go
@@ -112,24 +112,11 @@ func (cw *CacheWindow) Dispose() {
 
 func (cw *CacheWindow) Present() {
 	cw.ApplicationWindow.Present()
-	cw.RefreshMetadata()
-	cw.RefreshImages()
-}
-
-func (cw *CacheWindow) RefreshMetadataWith(metadata cache.Stat) {
-	metaf, err := metadata.Fraction()
-	if err != nil {
-		log.Print("error refreshing cache window: ", err)
-	}
-	cw.metadataLevelBar.SetFraction(metaf)
-	cw.metadataLevelBar.SetDetails(metadata.String())
+	go cw.RefreshMetadata()
+	go cw.RefreshImages()
 }
 
 func (cw *CacheWindow) RefreshMetadata() {
-	go cw.refreshMetadata()
-}
-
-func (cw *CacheWindow) refreshMetadata() {
 	if !cw.IsVisible() {
 		return
 	}
@@ -145,20 +132,16 @@ func (cw *CacheWindow) refreshMetadata() {
 	})
 }
 
-func (cw *CacheWindow) RefreshImagesWith(images cache.Stat) {
-	imgf, err := images.Fraction()
+func (cw *CacheWindow) RefreshMetadataWith(metadata cache.Stat) {
+	metaf, err := metadata.Fraction()
 	if err != nil {
 		log.Print("error refreshing cache window: ", err)
 	}
-	cw.imageLevelBar.SetFraction(imgf)
-	cw.imageLevelBar.SetDetails(images.String())
+	cw.metadataLevelBar.SetFraction(metaf)
+	cw.metadataLevelBar.SetDetails(metadata.String())
 }
 
 func (cw *CacheWindow) RefreshImages() {
-	go cw.refreshImages()
-}
-
-func (cw *CacheWindow) refreshImages() {
 	if !cw.IsVisible() {
 		return
 	}
@@ -172,6 +155,15 @@ func (cw *CacheWindow) refreshImages() {
 	glib.IdleAdd(func() {
 		cw.RefreshImagesWith(cs)
 	})
+}
+
+func (cw *CacheWindow) RefreshImagesWith(images cache.Stat) {
+	imgf, err := images.Fraction()
+	if err != nil {
+		log.Print("error refreshing cache window: ", err)
+	}
+	cw.imageLevelBar.SetFraction(imgf)
+	cw.imageLevelBar.SetDetails(images.String())
 }
 
 type labeledLevelBar struct {

--- a/internal/widget/cache-window.go
+++ b/internal/widget/cache-window.go
@@ -95,7 +95,7 @@ func NewCacheWindow(app Application) (*CacheWindow, error) {
 	registerAction("download-all-images", func() {
 		cw.actions["download-all-images"].SetEnabled(false)
 		go func() {
-			cache.DownloadAllComicImages(func() cache.ViewRefresher { return cw })
+			cache.DownloadAllComicImages(func() cache.ViewRefreshWither { return cw })
 			b := cw.actions["download-all-images"]
 			glib.IdleAdd(func() {
 				b.SetEnabled(true)

--- a/internal/widget/cache-window.go
+++ b/internal/widget/cache-window.go
@@ -8,12 +8,6 @@ import (
 	"github.com/rkoesters/xkcd-gtk/internal/style"
 )
 
-type CacheManager interface {
-	MetadataStats() (int, int, error)
-	ImageStats() (int, int, error)
-	DownloadImages()
-}
-
 type CacheWindow struct {
 	*gtk.ApplicationWindow
 

--- a/internal/widget/cache-window.go
+++ b/internal/widget/cache-window.go
@@ -1,0 +1,188 @@
+package widget
+
+import (
+	"log"
+
+	"github.com/gotk3/gotk3/glib"
+	"github.com/gotk3/gotk3/gtk"
+	"github.com/rkoesters/xkcd-gtk/internal/cache"
+	"github.com/rkoesters/xkcd-gtk/internal/style"
+)
+
+type CacheManager interface {
+	MetadataStats() (int, int, error)
+	ImageStats() (int, int, error)
+	DownloadImages()
+}
+
+type CacheWindow struct {
+	*gtk.ApplicationWindow
+	box              *gtk.Box
+	metadataLevelBar *labeledLevelBar
+	imageLevelBar    *labeledLevelBar
+}
+
+var _ Widget = &CacheWindow{}
+
+func NewCacheWindow(app Application) (*CacheWindow, error) {
+	super, err := gtk.ApplicationWindowNew(app.GtkApplication())
+	if err != nil {
+		return nil, err
+	}
+	super.SetTitle(l("Cache manager"))
+	super.SetSizeRequest(400, -1)
+	super.HideOnDelete()
+	super.Connect("hide", func(win gtk.IWindow) {
+		app.RemoveWindow(win)
+	})
+
+	box, err := gtk.BoxNew(gtk.ORIENTATION_VERTICAL, 0)
+	if err != nil {
+		return nil, err
+	}
+	box.SetMarginTop(style.PaddingPropertiesDialog)
+	box.SetMarginBottom(style.PaddingPropertiesDialog)
+	box.SetMarginStart(style.PaddingPropertiesDialog)
+	box.SetMarginEnd(style.PaddingPropertiesDialog)
+	super.Add(box)
+
+	mpb, err := newLabeledLevelBar(l("Cached comic metadata"))
+	if err != nil {
+		return nil, err
+	}
+	box.PackStart(mpb, false, true, 0)
+	ipb, err := newLabeledLevelBar(l("Cached comic images"))
+	if err != nil {
+		return nil, err
+	}
+	box.PackStart(ipb, false, true, 0)
+
+	cw := &CacheWindow{
+		ApplicationWindow: super,
+		box:               box,
+		metadataLevelBar:  mpb,
+		imageLevelBar:     ipb,
+	}
+	cw.box.ShowAll()
+
+	return cw, nil
+}
+
+func (cw *CacheWindow) Dispose() {
+	cw.ApplicationWindow = nil
+	cw.metadataLevelBar = nil
+	cw.imageLevelBar = nil
+}
+
+func (cw *CacheWindow) Present() {
+	cw.ApplicationWindow.Present()
+	cw.RefreshMetadata()
+	cw.RefreshImages()
+}
+
+func (cw *CacheWindow) RefreshMetadata() {
+	go cw.refreshMetadata()
+}
+
+func (cw *CacheWindow) refreshMetadata() {
+	if !cw.IsVisible() {
+		return
+	}
+
+	cs, err := cache.StatMetadata()
+	if err != nil {
+		log.Print("error refreshing cache window: ", err)
+		return
+	}
+
+	glib.IdleAdd(func() {
+		metaf, err := cs.Fraction()
+		if err != nil {
+			log.Print("error refreshing cache window: ", err)
+		}
+		cw.metadataLevelBar.SetFraction(metaf)
+		cw.metadataLevelBar.SetDetails(cs.String())
+	})
+}
+
+func (cw *CacheWindow) RefreshImages() {
+	go cw.refreshImages()
+}
+
+func (cw *CacheWindow) refreshImages() {
+	if !cw.IsVisible() {
+		return
+	}
+
+	cs, err := cache.StatImages()
+	if err != nil {
+		log.Print("error refreshing cache window: ", err)
+		return
+	}
+
+	glib.IdleAdd(func() {
+		imgf, err := cs.Fraction()
+		if err != nil {
+			log.Print("error refreshing cache window: ", err)
+		}
+		cw.imageLevelBar.SetFraction(imgf)
+		cw.imageLevelBar.SetDetails(cs.String())
+	})
+}
+
+type labeledLevelBar struct {
+	*gtk.Box
+	title   *gtk.Label
+	bar     *gtk.LevelBar
+	details *gtk.Label
+}
+
+func newLabeledLevelBar(title string) (*labeledLevelBar, error) {
+	super, err := gtk.BoxNew(gtk.ORIENTATION_VERTICAL, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	tl, err := gtk.LabelNew(title)
+	if err != nil {
+		return nil, err
+	}
+	tl.SetXAlign(0)
+	tl.SetYAlign(1)
+	super.PackStart(tl, false, true, 0)
+
+	lb, err := gtk.LevelBarNew()
+	if err != nil {
+		return nil, err
+	}
+	lb.SetMode(gtk.LEVEL_BAR_MODE_CONTINUOUS)
+	lb.RemoveOffsetValue(gtk.LEVEL_BAR_OFFSET_LOW)
+	lb.RemoveOffsetValue(gtk.LEVEL_BAR_OFFSET_HIGH)
+	lb.RemoveOffsetValue(gtk.LEVEL_BAR_OFFSET_FULL)
+	lb.SetMarginTop(6)
+	lb.SetMarginBottom(6)
+	super.PackStart(lb, false, true, 0)
+
+	dl, err := gtk.LabelNew("")
+	if err != nil {
+		return nil, err
+	}
+	dl.SetXAlign(1)
+	dl.SetYAlign(0)
+	super.PackStart(dl, false, true, 0)
+
+	return &labeledLevelBar{
+		Box:     super,
+		title:   tl,
+		bar:     lb,
+		details: dl,
+	}, nil
+}
+
+func (lpb *labeledLevelBar) SetFraction(f float64) {
+	lpb.bar.SetValue(f)
+}
+
+func (lpb *labeledLevelBar) SetDetails(s string) {
+	lpb.details.SetText(s)
+}

--- a/internal/widget/cache-window.go
+++ b/internal/widget/cache-window.go
@@ -1,11 +1,10 @@
 package widget
 
 import (
-	"log"
-
 	"github.com/gotk3/gotk3/glib"
 	"github.com/gotk3/gotk3/gtk"
 	"github.com/rkoesters/xkcd-gtk/internal/cache"
+	"github.com/rkoesters/xkcd-gtk/internal/log"
 	"github.com/rkoesters/xkcd-gtk/internal/style"
 )
 
@@ -105,6 +104,9 @@ func NewCacheWindow(app Application) (*CacheWindow, error) {
 }
 
 func (cw *CacheWindow) Dispose() {
+	if cw == nil {
+		return
+	}
 	cw.ApplicationWindow = nil
 	cw.actions = nil
 	cw.box = nil
@@ -117,6 +119,13 @@ func (cw *CacheWindow) Present() {
 	cw.ApplicationWindow.Present()
 	go cw.RefreshMetadata()
 	go cw.RefreshImages()
+}
+
+func (cw *CacheWindow) IsVisible() bool {
+	if cw == nil {
+		return false
+	}
+	return cw.ApplicationWindow.IsVisible()
 }
 
 func (cw *CacheWindow) RefreshMetadata() {
@@ -136,6 +145,10 @@ func (cw *CacheWindow) RefreshMetadata() {
 }
 
 func (cw *CacheWindow) RefreshMetadataWith(metadata cache.Stat) {
+	if !cw.IsVisible() {
+		return
+	}
+
 	metaf, err := metadata.Fraction()
 	if err != nil {
 		log.Print("error refreshing cache window: ", err)
@@ -161,6 +174,10 @@ func (cw *CacheWindow) RefreshImages() {
 }
 
 func (cw *CacheWindow) RefreshImagesWith(images cache.Stat) {
+	if !cw.IsVisible() {
+		return
+	}
+
 	imgf, err := images.Fraction()
 	if err != nil {
 		log.Print("error refreshing cache window: ", err)
@@ -219,9 +236,11 @@ func newLabeledLevelBar(title string) (*labeledLevelBar, error) {
 }
 
 func (lpb *labeledLevelBar) SetFraction(f float64) {
+	log.Debugf("labeledLevelBar.SetFraction(%q)", f)
 	lpb.bar.SetValue(f)
 }
 
 func (lpb *labeledLevelBar) SetDetails(s string) {
-	lpb.details.SetText(s)
+	log.Debugf("labeledLevelBar.SetDetails(%q)", s)
+	lpb.details.SetLabel(s)
 }

--- a/internal/widget/properties-dialog.go
+++ b/internal/widget/properties-dialog.go
@@ -78,12 +78,12 @@ func NewPropertiesDialog(parent *ApplicationWindow) (*PropertiesDialog, error) {
 	if err != nil {
 		return nil, err
 	}
-	grid.SetColumnSpacing(style.PaddingPropertiesDialog)
-	grid.SetRowSpacing(style.PaddingPropertiesDialog)
-	grid.SetMarginTop(style.PaddingPropertiesDialog)
-	grid.SetMarginBottom(style.PaddingPropertiesDialog)
-	grid.SetMarginStart(style.PaddingPropertiesDialog)
-	grid.SetMarginEnd(style.PaddingPropertiesDialog)
+	grid.SetColumnSpacing(style.PaddingAuxiliaryWindow)
+	grid.SetRowSpacing(style.PaddingAuxiliaryWindow)
+	grid.SetMarginTop(style.PaddingAuxiliaryWindow)
+	grid.SetMarginBottom(style.PaddingAuxiliaryWindow)
+	grid.SetMarginStart(style.PaddingAuxiliaryWindow)
+	grid.SetMarginEnd(style.PaddingAuxiliaryWindow)
 
 	row := 0
 

--- a/internal/widget/window-menu.go
+++ b/internal/widget/window-menu.go
@@ -83,20 +83,20 @@ func NewWindowMenu(accels *gtk.AccelGroup, prefersAppMenu bool, darkModeGetter f
 		return nil, err
 	}
 
-	wm.darkModeSwitch, err = NewDarkModeSwitch(darkModeGetter, darkModeSetter)
+	_, err = wm.popover.AddMenuEntry(l("Cache manager"), "app.show-cache")
 	if err != nil {
 		return nil, err
 	}
-	wm.popover.AddChild(wm.darkModeSwitch, 0)
 
 	if err = wm.popover.AddSeparator(); err != nil {
 		return nil, err
 	}
 
-	_, err = wm.popover.AddMenuEntry(l("Cache manager"), "app.show-cache")
+	wm.darkModeSwitch, err = NewDarkModeSwitch(darkModeGetter, darkModeSetter)
 	if err != nil {
 		return nil, err
 	}
+	wm.popover.AddChild(wm.darkModeSwitch, 0)
 
 	if err = wm.popover.AddSeparator(); err != nil {
 		return nil, err

--- a/internal/widget/window-menu.go
+++ b/internal/widget/window-menu.go
@@ -93,6 +93,15 @@ func NewWindowMenu(accels *gtk.AccelGroup, prefersAppMenu bool, darkModeGetter f
 		return nil, err
 	}
 
+	_, err = wm.popover.AddMenuEntry(l("Cache manager"), "app.show-cache")
+	if err != nil {
+		return nil, err
+	}
+
+	if err = wm.popover.AddSeparator(); err != nil {
+		return nil, err
+	}
+
 	_, err = wm.popover.AddMenuEntry(l("What If?"), "app.open-what-if")
 	if err != nil {
 		return nil, err
@@ -115,10 +124,6 @@ func NewWindowMenu(accels *gtk.AccelGroup, prefersAppMenu bool, darkModeGetter f
 	}
 
 	_, err = wm.popover.AddMenuEntry(l("Keyboard shortcuts"), "app.show-shortcuts")
-	if err != nil {
-		return nil, err
-	}
-	_, err = wm.popover.AddMenuEntry(l("Cache manager"), "app.show-cache")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/widget/window-menu.go
+++ b/internal/widget/window-menu.go
@@ -118,6 +118,10 @@ func NewWindowMenu(accels *gtk.AccelGroup, prefersAppMenu bool, darkModeGetter f
 	if err != nil {
 		return nil, err
 	}
+	_, err = wm.popover.AddMenuEntry(l("Cache manager"), "app.show-cache")
+	if err != nil {
+		return nil, err
+	}
 	_, err = wm.popover.AddMenuEntry(l("About"), "app.show-about")
 	if err != nil {
 		return nil, err

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -1,7 +1,6 @@
 data/com.github.rkoesters.xkcd-gtk.appdata.xml.in
 data/com.github.rkoesters.xkcd-gtk.desktop.in
 internal/cache/cache.go
-internal/search/index.go
 internal/widget/about-dialog.go
 internal/widget/app-menu.ui
 internal/widget/application-window.go

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -7,6 +7,7 @@ internal/widget/app-menu.ui
 internal/widget/application-window.go
 internal/widget/application.go
 internal/widget/bookmarks-menu.go
+internal/widget/cache-window.go
 internal/widget/context-menu.go
 internal/widget/dark-mode-switch.go
 internal/widget/navigation-bar.go

--- a/po/com.github.rkoesters.xkcd-gtk.pot
+++ b/po/com.github.rkoesters.xkcd-gtk.pot
@@ -53,8 +53,8 @@ msgstr ""
 msgid "Cache comics for later offline viewing"
 msgstr ""
 
-#: internal/widget/cache-window.go:34 internal/widget/window-menu.go:96
-#: internal/widget/app-menu.ui:18
+#: internal/widget/cache-window.go:34 internal/widget/window-menu.go:86
+#: internal/widget/app-menu.ui:12
 #: data/com.github.rkoesters.xkcd-gtk.desktop.in:23
 msgid "Cache manager"
 msgstr ""
@@ -268,7 +268,7 @@ msgstr ""
 msgid "Title"
 msgstr ""
 
-#: internal/widget/dark-mode-switch.go:42 internal/widget/app-menu.ui:12
+#: internal/widget/dark-mode-switch.go:42 internal/widget/app-menu.ui:18
 #: internal/widget/shortcuts-window.ui:156
 msgid "Toggle dark mode"
 msgstr ""

--- a/po/com.github.rkoesters.xkcd-gtk.pot
+++ b/po/com.github.rkoesters.xkcd-gtk.pot
@@ -53,17 +53,17 @@ msgstr ""
 msgid "Cache comics for later offline viewing"
 msgstr ""
 
-#: internal/widget/cache-window.go:36 internal/widget/window-menu.go:96
+#: internal/widget/cache-window.go:35 internal/widget/window-menu.go:96
 #: internal/widget/app-menu.ui:18
 #: data/com.github.rkoesters.xkcd-gtk.desktop.in:23
 msgid "Cache manager"
 msgstr ""
 
-#: internal/widget/cache-window.go:64
+#: internal/widget/cache-window.go:63
 msgid "Cached comic images"
 msgstr ""
 
-#: internal/widget/cache-window.go:58
+#: internal/widget/cache-window.go:57
 msgid "Cached comic metadata"
 msgstr ""
 
@@ -115,7 +115,7 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: internal/widget/cache-window.go:77
+#: internal/widget/cache-window.go:76
 msgid "Download all comic images"
 msgstr ""
 

--- a/po/com.github.rkoesters.xkcd-gtk.pot
+++ b/po/com.github.rkoesters.xkcd-gtk.pot
@@ -53,17 +53,17 @@ msgstr ""
 msgid "Cache comics for later offline viewing"
 msgstr ""
 
-#: internal/widget/cache-window.go:35 internal/widget/window-menu.go:96
+#: internal/widget/cache-window.go:29 internal/widget/window-menu.go:96
 #: internal/widget/app-menu.ui:18
 #: data/com.github.rkoesters.xkcd-gtk.desktop.in:23
 msgid "Cache manager"
 msgstr ""
 
-#: internal/widget/cache-window.go:63
+#: internal/widget/cache-window.go:57
 msgid "Cached comic images"
 msgstr ""
 
-#: internal/widget/cache-window.go:57
+#: internal/widget/cache-window.go:51
 msgid "Cached comic metadata"
 msgstr ""
 
@@ -115,7 +115,7 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: internal/widget/cache-window.go:76
+#: internal/widget/cache-window.go:70
 msgid "Download all comic images"
 msgstr ""
 

--- a/po/com.github.rkoesters.xkcd-gtk.pot
+++ b/po/com.github.rkoesters.xkcd-gtk.pot
@@ -277,7 +277,7 @@ msgstr ""
 msgid "Transcript"
 msgstr ""
 
-#: internal/widget/search-menu.go:73
+#: internal/widget/search-menu.go:66
 msgid "Updating comic search index..."
 msgstr ""
 

--- a/po/com.github.rkoesters.xkcd-gtk.pot
+++ b/po/com.github.rkoesters.xkcd-gtk.pot
@@ -53,16 +53,16 @@ msgstr ""
 msgid "Cache comics for later offline viewing"
 msgstr ""
 
-#: internal/widget/cache-window.go:32 internal/widget/window-menu.go:121
+#: internal/widget/cache-window.go:36 internal/widget/window-menu.go:121
 #: data/com.github.rkoesters.xkcd-gtk.desktop.in:27
 msgid "Cache manager"
 msgstr ""
 
-#: internal/widget/cache-window.go:54
+#: internal/widget/cache-window.go:64
 msgid "Cached comic images"
 msgstr ""
 
-#: internal/widget/cache-window.go:49
+#: internal/widget/cache-window.go:58
 msgid "Cached comic metadata"
 msgstr ""
 
@@ -112,6 +112,10 @@ msgstr ""
 
 #: internal/widget/properties-dialog.go:124
 msgid "Date"
+msgstr ""
+
+#: internal/widget/cache-window.go:77
+msgid "Download all comic images"
 msgstr ""
 
 #: internal/cache/cache.go:65

--- a/po/com.github.rkoesters.xkcd-gtk.pot
+++ b/po/com.github.rkoesters.xkcd-gtk.pot
@@ -53,17 +53,17 @@ msgstr ""
 msgid "Cache comics for later offline viewing"
 msgstr ""
 
-#: internal/widget/cache-window.go:34 internal/widget/window-menu.go:86
+#: internal/widget/cache-window.go:37 internal/widget/window-menu.go:86
 #: internal/widget/app-menu.ui:12
 #: data/com.github.rkoesters.xkcd-gtk.desktop.in:23
 msgid "Cache manager"
 msgstr ""
 
-#: internal/widget/cache-window.go:62
+#: internal/widget/cache-window.go:65
 msgid "Cached comic images"
 msgstr ""
 
-#: internal/widget/cache-window.go:56
+#: internal/widget/cache-window.go:59
 msgid "Cached comic metadata"
 msgstr ""
 
@@ -115,7 +115,7 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: internal/widget/cache-window.go:77
+#: internal/widget/cache-window.go:80
 msgid "Download all comic images"
 msgstr ""
 

--- a/po/com.github.rkoesters.xkcd-gtk.pot
+++ b/po/com.github.rkoesters.xkcd-gtk.pot
@@ -20,8 +20,8 @@ msgstr ""
 msgid "A simple xkcd viewer written in Go using GTK+3"
 msgstr ""
 
-#: internal/widget/window-menu.go:121 internal/widget/app-menu.ui:40
-#: data/com.github.rkoesters.xkcd-gtk.desktop.in:27
+#: internal/widget/window-menu.go:125 internal/widget/app-menu.ui:40
+#: data/com.github.rkoesters.xkcd-gtk.desktop.in:31
 msgid "About"
 msgstr ""
 
@@ -51,6 +51,19 @@ msgstr ""
 
 #: data/com.github.rkoesters.xkcd-gtk.appdata.xml.in:18
 msgid "Cache comics for later offline viewing"
+msgstr ""
+
+#: internal/widget/cache-window.go:32 internal/widget/window-menu.go:121
+#: data/com.github.rkoesters.xkcd-gtk.desktop.in:27
+msgid "Cache manager"
+msgstr ""
+
+#: internal/widget/cache-window.go:54
+msgid "Cached comic images"
+msgstr ""
+
+#: internal/widget/cache-window.go:49
+msgid "Cached comic metadata"
 msgstr ""
 
 #: internal/widget/application-window.go:290
@@ -238,10 +251,6 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: internal/search/index.go:71
-msgid "Search Index Update"
-msgstr ""
-
 #: internal/widget/search-menu.go:38 internal/widget/shortcuts-window.ui:83
 msgid "Search comics"
 msgstr ""
@@ -261,10 +270,6 @@ msgstr ""
 
 #: internal/widget/properties-dialog.go:144
 msgid "Transcript"
-msgstr ""
-
-#: internal/search/index.go:79
-msgid "Updating comic search index..."
 msgstr ""
 
 #: data/com.github.rkoesters.xkcd-gtk.appdata.xml.in:20

--- a/po/com.github.rkoesters.xkcd-gtk.pot
+++ b/po/com.github.rkoesters.xkcd-gtk.pot
@@ -190,7 +190,7 @@ msgstr ""
 msgid "News"
 msgstr ""
 
-#: internal/widget/search-menu.go:71
+#: internal/widget/search-menu.go:79
 msgid "No results found"
 msgstr ""
 
@@ -256,7 +256,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: internal/widget/search-menu.go:38 internal/widget/shortcuts-window.ui:83
+#: internal/widget/search-menu.go:40 internal/widget/shortcuts-window.ui:83
 msgid "Search comics"
 msgstr ""
 
@@ -275,6 +275,10 @@ msgstr ""
 
 #: internal/widget/properties-dialog.go:144
 msgid "Transcript"
+msgstr ""
+
+#: internal/widget/search-menu.go:73
+msgid "Updating comic search index..."
 msgstr ""
 
 #: data/com.github.rkoesters.xkcd-gtk.appdata.xml.in:20

--- a/po/com.github.rkoesters.xkcd-gtk.pot
+++ b/po/com.github.rkoesters.xkcd-gtk.pot
@@ -53,17 +53,17 @@ msgstr ""
 msgid "Cache comics for later offline viewing"
 msgstr ""
 
-#: internal/widget/cache-window.go:29 internal/widget/window-menu.go:96
+#: internal/widget/cache-window.go:34 internal/widget/window-menu.go:96
 #: internal/widget/app-menu.ui:18
 #: data/com.github.rkoesters.xkcd-gtk.desktop.in:23
 msgid "Cache manager"
 msgstr ""
 
-#: internal/widget/cache-window.go:57
+#: internal/widget/cache-window.go:62
 msgid "Cached comic images"
 msgstr ""
 
-#: internal/widget/cache-window.go:51
+#: internal/widget/cache-window.go:56
 msgid "Cached comic metadata"
 msgstr ""
 
@@ -115,7 +115,7 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: internal/widget/cache-window.go:70
+#: internal/widget/cache-window.go:77
 msgid "Download all comic images"
 msgstr ""
 

--- a/po/com.github.rkoesters.xkcd-gtk.pot
+++ b/po/com.github.rkoesters.xkcd-gtk.pot
@@ -20,12 +20,12 @@ msgstr ""
 msgid "A simple xkcd viewer written in Go using GTK+3"
 msgstr ""
 
-#: internal/widget/window-menu.go:125 internal/widget/app-menu.ui:40
+#: internal/widget/window-menu.go:130 internal/widget/app-menu.ui:46
 #: data/com.github.rkoesters.xkcd-gtk.desktop.in:31
 msgid "About"
 msgstr ""
 
-#: internal/widget/window-menu.go:108 internal/widget/app-menu.ui:30
+#: internal/widget/window-menu.go:117 internal/widget/app-menu.ui:36
 msgid "About xkcd"
 msgstr ""
 
@@ -53,8 +53,9 @@ msgstr ""
 msgid "Cache comics for later offline viewing"
 msgstr ""
 
-#: internal/widget/cache-window.go:36 internal/widget/window-menu.go:121
-#: data/com.github.rkoesters.xkcd-gtk.desktop.in:27
+#: internal/widget/cache-window.go:36 internal/widget/window-menu.go:96
+#: internal/widget/app-menu.ui:18
+#: data/com.github.rkoesters.xkcd-gtk.desktop.in:23
 msgid "Cache manager"
 msgstr ""
 
@@ -162,9 +163,9 @@ msgstr ""
 msgid "Keep track of comics with bookmarks"
 msgstr ""
 
-#: internal/widget/window-menu.go:117 internal/widget/app-menu.ui:36
+#: internal/widget/window-menu.go:126 internal/widget/app-menu.ui:42
 #: internal/widget/shortcuts-window.ui:4
-#: data/com.github.rkoesters.xkcd-gtk.desktop.in:23
+#: data/com.github.rkoesters.xkcd-gtk.desktop.in:27
 msgid "Keyboard shortcuts"
 msgstr ""
 
@@ -230,7 +231,7 @@ msgstr ""
 msgid "Quickly access comic explainations via the explain xkcd wiki"
 msgstr ""
 
-#: internal/widget/app-menu.ui:44
+#: internal/widget/app-menu.ui:50
 msgid "Quit"
 msgstr ""
 
@@ -280,7 +281,7 @@ msgstr ""
 msgid "View comic metadata"
 msgstr ""
 
-#: internal/widget/window-menu.go:96 internal/widget/app-menu.ui:18
+#: internal/widget/window-menu.go:105 internal/widget/app-menu.ui:24
 msgid "What If?"
 msgstr ""
 
@@ -308,10 +309,10 @@ msgstr ""
 msgid "webcomic;romance;sarcasm;math;language;"
 msgstr ""
 
-#: internal/widget/window-menu.go:100 internal/widget/app-menu.ui:22
+#: internal/widget/window-menu.go:109 internal/widget/app-menu.ui:28
 msgid "xkcd blog"
 msgstr ""
 
-#: internal/widget/window-menu.go:104 internal/widget/app-menu.ui:26
+#: internal/widget/window-menu.go:113 internal/widget/app-menu.ui:32
 msgid "xkcd books"
 msgstr ""

--- a/po/com.github.rkoesters.xkcd-gtk.pot
+++ b/po/com.github.rkoesters.xkcd-gtk.pot
@@ -75,7 +75,7 @@ msgstr ""
 msgid "Close window"
 msgstr ""
 
-#: internal/widget/application.go:10
+#: internal/widget/application.go:11
 #: data/com.github.rkoesters.xkcd-gtk.desktop.in:5
 #: data/com.github.rkoesters.xkcd-gtk.appdata.xml.in:10
 msgid "Comic Sticks"

--- a/po/fr.po
+++ b/po/fr.po
@@ -21,8 +21,8 @@ msgstr ""
 msgid "A simple xkcd viewer written in Go using GTK+3"
 msgstr "Une simple visionneuse pour XKCD écrite en Go avec GTK+3"
 
-#: internal/widget/window-menu.go:121 internal/widget/app-menu.ui:40
-#: data/com.github.rkoesters.xkcd-gtk.desktop.in:27
+#: internal/widget/window-menu.go:125 internal/widget/app-menu.ui:40
+#: data/com.github.rkoesters.xkcd-gtk.desktop.in:31
 msgid "About"
 msgstr "À propos"
 
@@ -53,6 +53,19 @@ msgstr ""
 #: data/com.github.rkoesters.xkcd-gtk.appdata.xml.in:18
 msgid "Cache comics for later offline viewing"
 msgstr "Sauvegardez des BD pour les regarder plus tard sans connexion"
+
+#: internal/widget/cache-window.go:32 internal/widget/window-menu.go:121
+#: data/com.github.rkoesters.xkcd-gtk.desktop.in:27
+msgid "Cache manager"
+msgstr ""
+
+#: internal/widget/cache-window.go:54
+msgid "Cached comic images"
+msgstr ""
+
+#: internal/widget/cache-window.go:49
+msgid "Cached comic metadata"
+msgstr ""
 
 #: internal/widget/application-window.go:290
 msgid "Checking for new comic..."
@@ -244,10 +257,6 @@ msgstr ""
 msgid "Search"
 msgstr "Rechercher"
 
-#: internal/search/index.go:71
-msgid "Search Index Update"
-msgstr "Rechercher une mise à jour de l'index"
-
 #: internal/widget/search-menu.go:38 internal/widget/shortcuts-window.ui:83
 msgid "Search comics"
 msgstr "Rechercher des BD"
@@ -268,10 +277,6 @@ msgstr "Activer le thème sombre"
 #: internal/widget/properties-dialog.go:144
 msgid "Transcript"
 msgstr "Transcription"
-
-#: internal/search/index.go:79
-msgid "Updating comic search index..."
-msgstr "Mise à jour de l'index de recherche des BD…"
 
 #: data/com.github.rkoesters.xkcd-gtk.appdata.xml.in:20
 msgid "View comic metadata"
@@ -312,6 +317,12 @@ msgstr "Blog xkcd"
 #: internal/widget/window-menu.go:104 internal/widget/app-menu.ui:26
 msgid "xkcd books"
 msgstr ""
+
+#~ msgid "Search Index Update"
+#~ msgstr "Rechercher une mise à jour de l'index"
+
+#~ msgid "Updating comic search index..."
+#~ msgstr "Mise à jour de l'index de recherche des BD…"
 
 #~ msgid "xkcd store"
 #~ msgstr "Boutique xkcd"

--- a/po/fr.po
+++ b/po/fr.po
@@ -54,17 +54,17 @@ msgstr ""
 msgid "Cache comics for later offline viewing"
 msgstr "Sauvegardez des BD pour les regarder plus tard sans connexion"
 
-#: internal/widget/cache-window.go:36 internal/widget/window-menu.go:96
+#: internal/widget/cache-window.go:35 internal/widget/window-menu.go:96
 #: internal/widget/app-menu.ui:18
 #: data/com.github.rkoesters.xkcd-gtk.desktop.in:23
 msgid "Cache manager"
 msgstr ""
 
-#: internal/widget/cache-window.go:64
+#: internal/widget/cache-window.go:63
 msgid "Cached comic images"
 msgstr ""
 
-#: internal/widget/cache-window.go:58
+#: internal/widget/cache-window.go:57
 msgid "Cached comic metadata"
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Thème sombre pour une lecture tardive"
 msgid "Date"
 msgstr "Date"
 
-#: internal/widget/cache-window.go:77
+#: internal/widget/cache-window.go:76
 msgid "Download all comic images"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -76,7 +76,7 @@ msgstr "Recherche d'une nouvelle bande dessinée…"
 msgid "Close window"
 msgstr ""
 
-#: internal/widget/application.go:10
+#: internal/widget/application.go:11
 #: data/com.github.rkoesters.xkcd-gtk.desktop.in:5
 #: data/com.github.rkoesters.xkcd-gtk.appdata.xml.in:10
 msgid "Comic Sticks"

--- a/po/fr.po
+++ b/po/fr.po
@@ -54,8 +54,8 @@ msgstr ""
 msgid "Cache comics for later offline viewing"
 msgstr "Sauvegardez des BD pour les regarder plus tard sans connexion"
 
-#: internal/widget/cache-window.go:34 internal/widget/window-menu.go:96
-#: internal/widget/app-menu.ui:18
+#: internal/widget/cache-window.go:34 internal/widget/window-menu.go:86
+#: internal/widget/app-menu.ui:12
 #: data/com.github.rkoesters.xkcd-gtk.desktop.in:23
 msgid "Cache manager"
 msgstr ""
@@ -274,7 +274,7 @@ msgstr "Recherchez des BD"
 msgid "Title"
 msgstr "Titre"
 
-#: internal/widget/dark-mode-switch.go:42 internal/widget/app-menu.ui:12
+#: internal/widget/dark-mode-switch.go:42 internal/widget/app-menu.ui:18
 #: internal/widget/shortcuts-window.ui:156
 msgid "Toggle dark mode"
 msgstr "Activer le thème sombre"

--- a/po/fr.po
+++ b/po/fr.po
@@ -54,16 +54,16 @@ msgstr ""
 msgid "Cache comics for later offline viewing"
 msgstr "Sauvegardez des BD pour les regarder plus tard sans connexion"
 
-#: internal/widget/cache-window.go:32 internal/widget/window-menu.go:121
+#: internal/widget/cache-window.go:36 internal/widget/window-menu.go:121
 #: data/com.github.rkoesters.xkcd-gtk.desktop.in:27
 msgid "Cache manager"
 msgstr ""
 
-#: internal/widget/cache-window.go:54
+#: internal/widget/cache-window.go:64
 msgid "Cached comic images"
 msgstr ""
 
-#: internal/widget/cache-window.go:49
+#: internal/widget/cache-window.go:58
 msgid "Cached comic metadata"
 msgstr ""
 
@@ -117,6 +117,10 @@ msgstr "Thème sombre pour une lecture tardive"
 #: internal/widget/properties-dialog.go:124
 msgid "Date"
 msgstr "Date"
+
+#: internal/widget/cache-window.go:77
+msgid "Download all comic images"
+msgstr ""
 
 #: internal/cache/cache.go:65
 msgid "Error reading local comic database"

--- a/po/fr.po
+++ b/po/fr.po
@@ -54,17 +54,17 @@ msgstr ""
 msgid "Cache comics for later offline viewing"
 msgstr "Sauvegardez des BD pour les regarder plus tard sans connexion"
 
-#: internal/widget/cache-window.go:34 internal/widget/window-menu.go:86
+#: internal/widget/cache-window.go:37 internal/widget/window-menu.go:86
 #: internal/widget/app-menu.ui:12
 #: data/com.github.rkoesters.xkcd-gtk.desktop.in:23
 msgid "Cache manager"
 msgstr ""
 
-#: internal/widget/cache-window.go:62
+#: internal/widget/cache-window.go:65
 msgid "Cached comic images"
 msgstr ""
 
-#: internal/widget/cache-window.go:56
+#: internal/widget/cache-window.go:59
 msgid "Cached comic metadata"
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Thème sombre pour une lecture tardive"
 msgid "Date"
 msgstr "Date"
 
-#: internal/widget/cache-window.go:77
+#: internal/widget/cache-window.go:80
 msgid "Download all comic images"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -194,7 +194,7 @@ msgstr "Nouvelle fenêtre"
 msgid "News"
 msgstr "Actualités"
 
-#: internal/widget/search-menu.go:71
+#: internal/widget/search-menu.go:79
 msgid "No results found"
 msgstr ""
 
@@ -262,7 +262,7 @@ msgstr ""
 msgid "Search"
 msgstr "Rechercher"
 
-#: internal/widget/search-menu.go:38 internal/widget/shortcuts-window.ui:83
+#: internal/widget/search-menu.go:40 internal/widget/shortcuts-window.ui:83
 msgid "Search comics"
 msgstr "Rechercher des BD"
 
@@ -282,6 +282,10 @@ msgstr "Activer le thème sombre"
 #: internal/widget/properties-dialog.go:144
 msgid "Transcript"
 msgstr "Transcription"
+
+#: internal/widget/search-menu.go:73
+msgid "Updating comic search index..."
+msgstr "Mise à jour de l'index de recherche des BD…"
 
 #: data/com.github.rkoesters.xkcd-gtk.appdata.xml.in:20
 msgid "View comic metadata"
@@ -325,9 +329,6 @@ msgstr ""
 
 #~ msgid "Search Index Update"
 #~ msgstr "Rechercher une mise à jour de l'index"
-
-#~ msgid "Updating comic search index..."
-#~ msgstr "Mise à jour de l'index de recherche des BD…"
 
 #~ msgid "xkcd store"
 #~ msgstr "Boutique xkcd"

--- a/po/fr.po
+++ b/po/fr.po
@@ -54,17 +54,17 @@ msgstr ""
 msgid "Cache comics for later offline viewing"
 msgstr "Sauvegardez des BD pour les regarder plus tard sans connexion"
 
-#: internal/widget/cache-window.go:29 internal/widget/window-menu.go:96
+#: internal/widget/cache-window.go:34 internal/widget/window-menu.go:96
 #: internal/widget/app-menu.ui:18
 #: data/com.github.rkoesters.xkcd-gtk.desktop.in:23
 msgid "Cache manager"
 msgstr ""
 
-#: internal/widget/cache-window.go:57
+#: internal/widget/cache-window.go:62
 msgid "Cached comic images"
 msgstr ""
 
-#: internal/widget/cache-window.go:51
+#: internal/widget/cache-window.go:56
 msgid "Cached comic metadata"
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Thème sombre pour une lecture tardive"
 msgid "Date"
 msgstr "Date"
 
-#: internal/widget/cache-window.go:70
+#: internal/widget/cache-window.go:77
 msgid "Download all comic images"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -21,12 +21,12 @@ msgstr ""
 msgid "A simple xkcd viewer written in Go using GTK+3"
 msgstr "Une simple visionneuse pour XKCD écrite en Go avec GTK+3"
 
-#: internal/widget/window-menu.go:125 internal/widget/app-menu.ui:40
+#: internal/widget/window-menu.go:130 internal/widget/app-menu.ui:46
 #: data/com.github.rkoesters.xkcd-gtk.desktop.in:31
 msgid "About"
 msgstr "À propos"
 
-#: internal/widget/window-menu.go:108 internal/widget/app-menu.ui:30
+#: internal/widget/window-menu.go:117 internal/widget/app-menu.ui:36
 msgid "About xkcd"
 msgstr "À propos de xkcd"
 
@@ -54,8 +54,9 @@ msgstr ""
 msgid "Cache comics for later offline viewing"
 msgstr "Sauvegardez des BD pour les regarder plus tard sans connexion"
 
-#: internal/widget/cache-window.go:36 internal/widget/window-menu.go:121
-#: data/com.github.rkoesters.xkcd-gtk.desktop.in:27
+#: internal/widget/cache-window.go:36 internal/widget/window-menu.go:96
+#: internal/widget/app-menu.ui:18
+#: data/com.github.rkoesters.xkcd-gtk.desktop.in:23
 msgid "Cache manager"
 msgstr ""
 
@@ -166,9 +167,9 @@ msgstr "Image"
 msgid "Keep track of comics with bookmarks"
 msgstr ""
 
-#: internal/widget/window-menu.go:117 internal/widget/app-menu.ui:36
+#: internal/widget/window-menu.go:126 internal/widget/app-menu.ui:42
 #: internal/widget/shortcuts-window.ui:4
-#: data/com.github.rkoesters.xkcd-gtk.desktop.in:23
+#: data/com.github.rkoesters.xkcd-gtk.desktop.in:27
 msgid "Keyboard shortcuts"
 msgstr "Raccourcis clavier"
 
@@ -234,7 +235,7 @@ msgstr "Propriétés"
 msgid "Quickly access comic explainations via the explain xkcd wiki"
 msgstr "Accédez rapidement aux explications de la BD via le wiki de XKCD"
 
-#: internal/widget/app-menu.ui:44
+#: internal/widget/app-menu.ui:50
 msgid "Quit"
 msgstr "Quitter"
 
@@ -286,7 +287,7 @@ msgstr "Transcription"
 msgid "View comic metadata"
 msgstr "Visualisez les métadonnées des BD"
 
-#: internal/widget/window-menu.go:96 internal/widget/app-menu.ui:18
+#: internal/widget/window-menu.go:105 internal/widget/app-menu.ui:24
 msgid "What If?"
 msgstr "What If?"
 
@@ -314,11 +315,11 @@ msgstr ""
 msgid "webcomic;romance;sarcasm;math;language;"
 msgstr "webcomic;romance;sarcasme;maths;langue;"
 
-#: internal/widget/window-menu.go:100 internal/widget/app-menu.ui:22
+#: internal/widget/window-menu.go:109 internal/widget/app-menu.ui:28
 msgid "xkcd blog"
 msgstr "Blog xkcd"
 
-#: internal/widget/window-menu.go:104 internal/widget/app-menu.ui:26
+#: internal/widget/window-menu.go:113 internal/widget/app-menu.ui:32
 msgid "xkcd books"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -54,17 +54,17 @@ msgstr ""
 msgid "Cache comics for later offline viewing"
 msgstr "Sauvegardez des BD pour les regarder plus tard sans connexion"
 
-#: internal/widget/cache-window.go:35 internal/widget/window-menu.go:96
+#: internal/widget/cache-window.go:29 internal/widget/window-menu.go:96
 #: internal/widget/app-menu.ui:18
 #: data/com.github.rkoesters.xkcd-gtk.desktop.in:23
 msgid "Cache manager"
 msgstr ""
 
-#: internal/widget/cache-window.go:63
+#: internal/widget/cache-window.go:57
 msgid "Cached comic images"
 msgstr ""
 
-#: internal/widget/cache-window.go:57
+#: internal/widget/cache-window.go:51
 msgid "Cached comic metadata"
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr "Thème sombre pour une lecture tardive"
 msgid "Date"
 msgstr "Date"
 
-#: internal/widget/cache-window.go:76
+#: internal/widget/cache-window.go:70
 msgid "Download all comic images"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -283,7 +283,7 @@ msgstr "Activer le thème sombre"
 msgid "Transcript"
 msgstr "Transcription"
 
-#: internal/widget/search-menu.go:73
+#: internal/widget/search-menu.go:66
 msgid "Updating comic search index..."
 msgstr "Mise à jour de l'index de recherche des BD…"
 

--- a/po/it.po
+++ b/po/it.po
@@ -76,7 +76,7 @@ msgstr "Verifica di nuovi fumetti..."
 msgid "Close window"
 msgstr ""
 
-#: internal/widget/application.go:10
+#: internal/widget/application.go:11
 #: data/com.github.rkoesters.xkcd-gtk.desktop.in:5
 #: data/com.github.rkoesters.xkcd-gtk.appdata.xml.in:10
 msgid "Comic Sticks"

--- a/po/it.po
+++ b/po/it.po
@@ -21,12 +21,12 @@ msgstr ""
 msgid "A simple xkcd viewer written in Go using GTK+3"
 msgstr "Un semplice visualizzatore xkcd scritto in Go usando GTK+3"
 
-#: internal/widget/window-menu.go:125 internal/widget/app-menu.ui:40
+#: internal/widget/window-menu.go:130 internal/widget/app-menu.ui:46
 #: data/com.github.rkoesters.xkcd-gtk.desktop.in:31
 msgid "About"
 msgstr "Informazioni"
 
-#: internal/widget/window-menu.go:108 internal/widget/app-menu.ui:30
+#: internal/widget/window-menu.go:117 internal/widget/app-menu.ui:36
 msgid "About xkcd"
 msgstr "Informazioni su xkcd"
 
@@ -54,8 +54,9 @@ msgstr "Segnalibri"
 msgid "Cache comics for later offline viewing"
 msgstr "Fumetti della cache per una successiva visualizzazione offline"
 
-#: internal/widget/cache-window.go:36 internal/widget/window-menu.go:121
-#: data/com.github.rkoesters.xkcd-gtk.desktop.in:27
+#: internal/widget/cache-window.go:36 internal/widget/window-menu.go:96
+#: internal/widget/app-menu.ui:18
+#: data/com.github.rkoesters.xkcd-gtk.desktop.in:23
 msgid "Cache manager"
 msgstr ""
 
@@ -165,9 +166,9 @@ msgstr "Immagine"
 msgid "Keep track of comics with bookmarks"
 msgstr "Tieni traccia dei fumetti con i segnalibri"
 
-#: internal/widget/window-menu.go:117 internal/widget/app-menu.ui:36
+#: internal/widget/window-menu.go:126 internal/widget/app-menu.ui:42
 #: internal/widget/shortcuts-window.ui:4
-#: data/com.github.rkoesters.xkcd-gtk.desktop.in:23
+#: data/com.github.rkoesters.xkcd-gtk.desktop.in:27
 msgid "Keyboard shortcuts"
 msgstr "Tasti Rapidi"
 
@@ -235,7 +236,7 @@ msgstr ""
 "Accedi rapidamente alle spiegazioni dei fumetti tramite il wiki esplicativo "
 "di xkcd"
 
-#: internal/widget/app-menu.ui:44
+#: internal/widget/app-menu.ui:50
 msgid "Quit"
 msgstr "Esci"
 
@@ -285,7 +286,7 @@ msgstr "Trascrizione"
 msgid "View comic metadata"
 msgstr "Visualizza metadati fumetto"
 
-#: internal/widget/window-menu.go:96 internal/widget/app-menu.ui:18
+#: internal/widget/window-menu.go:105 internal/widget/app-menu.ui:24
 msgid "What If?"
 msgstr "E se?"
 
@@ -313,11 +314,11 @@ msgstr ""
 msgid "webcomic;romance;sarcasm;math;language;"
 msgstr "webcomic;romanticismo;sarcasmo;matematica;lingua;"
 
-#: internal/widget/window-menu.go:100 internal/widget/app-menu.ui:22
+#: internal/widget/window-menu.go:109 internal/widget/app-menu.ui:28
 msgid "xkcd blog"
 msgstr "xkcd blog"
 
-#: internal/widget/window-menu.go:104 internal/widget/app-menu.ui:26
+#: internal/widget/window-menu.go:113 internal/widget/app-menu.ui:32
 msgid "xkcd books"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -54,17 +54,17 @@ msgstr "Segnalibri"
 msgid "Cache comics for later offline viewing"
 msgstr "Fumetti della cache per una successiva visualizzazione offline"
 
-#: internal/widget/cache-window.go:34 internal/widget/window-menu.go:86
+#: internal/widget/cache-window.go:37 internal/widget/window-menu.go:86
 #: internal/widget/app-menu.ui:12
 #: data/com.github.rkoesters.xkcd-gtk.desktop.in:23
 msgid "Cache manager"
 msgstr ""
 
-#: internal/widget/cache-window.go:62
+#: internal/widget/cache-window.go:65
 msgid "Cached comic images"
 msgstr ""
 
-#: internal/widget/cache-window.go:56
+#: internal/widget/cache-window.go:59
 msgid "Cached comic metadata"
 msgstr ""
 
@@ -118,7 +118,7 @@ msgstr "Modalità scura per la lettura a tarda notte"
 msgid "Date"
 msgstr "Data"
 
-#: internal/widget/cache-window.go:77
+#: internal/widget/cache-window.go:80
 msgid "Download all comic images"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -54,17 +54,17 @@ msgstr "Segnalibri"
 msgid "Cache comics for later offline viewing"
 msgstr "Fumetti della cache per una successiva visualizzazione offline"
 
-#: internal/widget/cache-window.go:36 internal/widget/window-menu.go:96
+#: internal/widget/cache-window.go:35 internal/widget/window-menu.go:96
 #: internal/widget/app-menu.ui:18
 #: data/com.github.rkoesters.xkcd-gtk.desktop.in:23
 msgid "Cache manager"
 msgstr ""
 
-#: internal/widget/cache-window.go:64
+#: internal/widget/cache-window.go:63
 msgid "Cached comic images"
 msgstr ""
 
-#: internal/widget/cache-window.go:58
+#: internal/widget/cache-window.go:57
 msgid "Cached comic metadata"
 msgstr ""
 
@@ -118,7 +118,7 @@ msgstr "Modalità scura per la lettura a tarda notte"
 msgid "Date"
 msgstr "Data"
 
-#: internal/widget/cache-window.go:77
+#: internal/widget/cache-window.go:76
 msgid "Download all comic images"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -54,17 +54,17 @@ msgstr "Segnalibri"
 msgid "Cache comics for later offline viewing"
 msgstr "Fumetti della cache per una successiva visualizzazione offline"
 
-#: internal/widget/cache-window.go:29 internal/widget/window-menu.go:96
+#: internal/widget/cache-window.go:34 internal/widget/window-menu.go:96
 #: internal/widget/app-menu.ui:18
 #: data/com.github.rkoesters.xkcd-gtk.desktop.in:23
 msgid "Cache manager"
 msgstr ""
 
-#: internal/widget/cache-window.go:57
+#: internal/widget/cache-window.go:62
 msgid "Cached comic images"
 msgstr ""
 
-#: internal/widget/cache-window.go:51
+#: internal/widget/cache-window.go:56
 msgid "Cached comic metadata"
 msgstr ""
 
@@ -118,7 +118,7 @@ msgstr "Modalità scura per la lettura a tarda notte"
 msgid "Date"
 msgstr "Data"
 
-#: internal/widget/cache-window.go:70
+#: internal/widget/cache-window.go:77
 msgid "Download all comic images"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -193,7 +193,7 @@ msgstr "Nuova Finestra"
 msgid "News"
 msgstr "Novità"
 
-#: internal/widget/search-menu.go:71
+#: internal/widget/search-menu.go:79
 msgid "No results found"
 msgstr "Nessun risultato trovato"
 
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Search"
 msgstr "Cerca"
 
-#: internal/widget/search-menu.go:38 internal/widget/shortcuts-window.ui:83
+#: internal/widget/search-menu.go:40 internal/widget/shortcuts-window.ui:83
 msgid "Search comics"
 msgstr "Cerca fumetti"
 
@@ -281,6 +281,10 @@ msgstr "Abilità modalità scura"
 #: internal/widget/properties-dialog.go:144
 msgid "Transcript"
 msgstr "Trascrizione"
+
+#: internal/widget/search-menu.go:73
+msgid "Updating comic search index..."
+msgstr "Aggiornamento dell'indice di ricerca del fumetto..."
 
 #: data/com.github.rkoesters.xkcd-gtk.appdata.xml.in:20
 msgid "View comic metadata"
@@ -324,9 +328,6 @@ msgstr ""
 
 #~ msgid "Search Index Update"
 #~ msgstr "Cerca aggiornamento indice"
-
-#~ msgid "Updating comic search index..."
-#~ msgstr "Aggiornamento dell'indice di ricerca del fumetto..."
 
 #~ msgid "xkcd store"
 #~ msgstr "xkcd store"

--- a/po/it.po
+++ b/po/it.po
@@ -54,17 +54,17 @@ msgstr "Segnalibri"
 msgid "Cache comics for later offline viewing"
 msgstr "Fumetti della cache per una successiva visualizzazione offline"
 
-#: internal/widget/cache-window.go:35 internal/widget/window-menu.go:96
+#: internal/widget/cache-window.go:29 internal/widget/window-menu.go:96
 #: internal/widget/app-menu.ui:18
 #: data/com.github.rkoesters.xkcd-gtk.desktop.in:23
 msgid "Cache manager"
 msgstr ""
 
-#: internal/widget/cache-window.go:63
+#: internal/widget/cache-window.go:57
 msgid "Cached comic images"
 msgstr ""
 
-#: internal/widget/cache-window.go:57
+#: internal/widget/cache-window.go:51
 msgid "Cached comic metadata"
 msgstr ""
 
@@ -118,7 +118,7 @@ msgstr "Modalità scura per la lettura a tarda notte"
 msgid "Date"
 msgstr "Data"
 
-#: internal/widget/cache-window.go:76
+#: internal/widget/cache-window.go:70
 msgid "Download all comic images"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -282,7 +282,7 @@ msgstr "Abilità modalità scura"
 msgid "Transcript"
 msgstr "Trascrizione"
 
-#: internal/widget/search-menu.go:73
+#: internal/widget/search-menu.go:66
 msgid "Updating comic search index..."
 msgstr "Aggiornamento dell'indice di ricerca del fumetto..."
 

--- a/po/it.po
+++ b/po/it.po
@@ -54,16 +54,16 @@ msgstr "Segnalibri"
 msgid "Cache comics for later offline viewing"
 msgstr "Fumetti della cache per una successiva visualizzazione offline"
 
-#: internal/widget/cache-window.go:32 internal/widget/window-menu.go:121
+#: internal/widget/cache-window.go:36 internal/widget/window-menu.go:121
 #: data/com.github.rkoesters.xkcd-gtk.desktop.in:27
 msgid "Cache manager"
 msgstr ""
 
-#: internal/widget/cache-window.go:54
+#: internal/widget/cache-window.go:64
 msgid "Cached comic images"
 msgstr ""
 
-#: internal/widget/cache-window.go:49
+#: internal/widget/cache-window.go:58
 msgid "Cached comic metadata"
 msgstr ""
 
@@ -116,6 +116,10 @@ msgstr "Modalità scura per la lettura a tarda notte"
 #: internal/widget/properties-dialog.go:124
 msgid "Date"
 msgstr "Data"
+
+#: internal/widget/cache-window.go:77
+msgid "Download all comic images"
+msgstr ""
 
 #: internal/cache/cache.go:65
 msgid "Error reading local comic database"

--- a/po/it.po
+++ b/po/it.po
@@ -21,8 +21,8 @@ msgstr ""
 msgid "A simple xkcd viewer written in Go using GTK+3"
 msgstr "Un semplice visualizzatore xkcd scritto in Go usando GTK+3"
 
-#: internal/widget/window-menu.go:121 internal/widget/app-menu.ui:40
-#: data/com.github.rkoesters.xkcd-gtk.desktop.in:27
+#: internal/widget/window-menu.go:125 internal/widget/app-menu.ui:40
+#: data/com.github.rkoesters.xkcd-gtk.desktop.in:31
 msgid "About"
 msgstr "Informazioni"
 
@@ -53,6 +53,19 @@ msgstr "Segnalibri"
 #: data/com.github.rkoesters.xkcd-gtk.appdata.xml.in:18
 msgid "Cache comics for later offline viewing"
 msgstr "Fumetti della cache per una successiva visualizzazione offline"
+
+#: internal/widget/cache-window.go:32 internal/widget/window-menu.go:121
+#: data/com.github.rkoesters.xkcd-gtk.desktop.in:27
+msgid "Cache manager"
+msgstr ""
+
+#: internal/widget/cache-window.go:54
+msgid "Cached comic images"
+msgstr ""
+
+#: internal/widget/cache-window.go:49
+msgid "Cached comic metadata"
+msgstr ""
 
 #: internal/widget/application-window.go:290
 msgid "Checking for new comic..."
@@ -243,10 +256,6 @@ msgstr ""
 msgid "Search"
 msgstr "Cerca"
 
-#: internal/search/index.go:71
-msgid "Search Index Update"
-msgstr "Cerca aggiornamento indice"
-
 #: internal/widget/search-menu.go:38 internal/widget/shortcuts-window.ui:83
 msgid "Search comics"
 msgstr "Cerca fumetti"
@@ -267,10 +276,6 @@ msgstr "Abilità modalità scura"
 #: internal/widget/properties-dialog.go:144
 msgid "Transcript"
 msgstr "Trascrizione"
-
-#: internal/search/index.go:79
-msgid "Updating comic search index..."
-msgstr "Aggiornamento dell'indice di ricerca del fumetto..."
 
 #: data/com.github.rkoesters.xkcd-gtk.appdata.xml.in:20
 msgid "View comic metadata"
@@ -311,6 +316,12 @@ msgstr "xkcd blog"
 #: internal/widget/window-menu.go:104 internal/widget/app-menu.ui:26
 msgid "xkcd books"
 msgstr ""
+
+#~ msgid "Search Index Update"
+#~ msgstr "Cerca aggiornamento indice"
+
+#~ msgid "Updating comic search index..."
+#~ msgstr "Aggiornamento dell'indice di ricerca del fumetto..."
 
 #~ msgid "xkcd store"
 #~ msgstr "xkcd store"

--- a/po/it.po
+++ b/po/it.po
@@ -54,8 +54,8 @@ msgstr "Segnalibri"
 msgid "Cache comics for later offline viewing"
 msgstr "Fumetti della cache per una successiva visualizzazione offline"
 
-#: internal/widget/cache-window.go:34 internal/widget/window-menu.go:96
-#: internal/widget/app-menu.ui:18
+#: internal/widget/cache-window.go:34 internal/widget/window-menu.go:86
+#: internal/widget/app-menu.ui:12
 #: data/com.github.rkoesters.xkcd-gtk.desktop.in:23
 msgid "Cache manager"
 msgstr ""
@@ -273,7 +273,7 @@ msgstr "Cerca fumetti"
 msgid "Title"
 msgstr "Titolo"
 
-#: internal/widget/dark-mode-switch.go:42 internal/widget/app-menu.ui:12
+#: internal/widget/dark-mode-switch.go:42 internal/widget/app-menu.ui:18
 #: internal/widget/shortcuts-window.ui:156
 msgid "Toggle dark mode"
 msgstr "Abilità modalità scura"

--- a/po/nl.po
+++ b/po/nl.po
@@ -57,17 +57,17 @@ msgstr "Bladwijzers"
 msgid "Cache comics for later offline viewing"
 msgstr "Sla verhalen op voor offline weergave"
 
-#: internal/widget/cache-window.go:35 internal/widget/window-menu.go:96
+#: internal/widget/cache-window.go:29 internal/widget/window-menu.go:96
 #: internal/widget/app-menu.ui:18
 #: data/com.github.rkoesters.xkcd-gtk.desktop.in:23
 msgid "Cache manager"
 msgstr ""
 
-#: internal/widget/cache-window.go:63
+#: internal/widget/cache-window.go:57
 msgid "Cached comic images"
 msgstr ""
 
-#: internal/widget/cache-window.go:57
+#: internal/widget/cache-window.go:51
 msgid "Cached comic metadata"
 msgstr ""
 
@@ -121,7 +121,7 @@ msgstr "Donker thema voor de late avonduurtjes"
 msgid "Date"
 msgstr "Datum"
 
-#: internal/widget/cache-window.go:76
+#: internal/widget/cache-window.go:70
 msgid "Download all comic images"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -24,8 +24,8 @@ msgstr ""
 "Een eenvoudige toepassing om de xkcd-strip te lezen, geschreven in Go en "
 "GTK+3"
 
-#: internal/widget/window-menu.go:121 internal/widget/app-menu.ui:40
-#: data/com.github.rkoesters.xkcd-gtk.desktop.in:27
+#: internal/widget/window-menu.go:125 internal/widget/app-menu.ui:40
+#: data/com.github.rkoesters.xkcd-gtk.desktop.in:31
 msgid "About"
 msgstr "Over"
 
@@ -56,6 +56,19 @@ msgstr "Bladwijzers"
 #: data/com.github.rkoesters.xkcd-gtk.appdata.xml.in:18
 msgid "Cache comics for later offline viewing"
 msgstr "Sla verhalen op voor offline weergave"
+
+#: internal/widget/cache-window.go:32 internal/widget/window-menu.go:121
+#: data/com.github.rkoesters.xkcd-gtk.desktop.in:27
+msgid "Cache manager"
+msgstr ""
+
+#: internal/widget/cache-window.go:54
+msgid "Cached comic images"
+msgstr ""
+
+#: internal/widget/cache-window.go:49
+msgid "Cached comic metadata"
+msgstr ""
 
 #: internal/widget/application-window.go:290
 msgid "Checking for new comic..."
@@ -244,10 +257,6 @@ msgstr "Oorspronkelijk zoomniveau"
 msgid "Search"
 msgstr "Zoeken"
 
-#: internal/search/index.go:71
-msgid "Search Index Update"
-msgstr "Zoekindex bijwerken"
-
 #: internal/widget/search-menu.go:38 internal/widget/shortcuts-window.ui:83
 msgid "Search comics"
 msgstr "Verhalen doorzoeken"
@@ -268,10 +277,6 @@ msgstr "Donker thema aan/uit"
 #: internal/widget/properties-dialog.go:144
 msgid "Transcript"
 msgstr "Transcriptie"
-
-#: internal/search/index.go:79
-msgid "Updating comic search index..."
-msgstr "Bezig met bijwerken van zoekindex…"
 
 #: data/com.github.rkoesters.xkcd-gtk.appdata.xml.in:20
 msgid "View comic metadata"
@@ -312,6 +317,12 @@ msgstr "xkcd-blog"
 #: internal/widget/window-menu.go:104 internal/widget/app-menu.ui:26
 msgid "xkcd books"
 msgstr ""
+
+#~ msgid "Search Index Update"
+#~ msgstr "Zoekindex bijwerken"
+
+#~ msgid "Updating comic search index..."
+#~ msgstr "Bezig met bijwerken van zoekindex…"
 
 #~ msgid "xkcd store"
 #~ msgstr "xkcd-winkel"

--- a/po/nl.po
+++ b/po/nl.po
@@ -57,17 +57,17 @@ msgstr "Bladwijzers"
 msgid "Cache comics for later offline viewing"
 msgstr "Sla verhalen op voor offline weergave"
 
-#: internal/widget/cache-window.go:36 internal/widget/window-menu.go:96
+#: internal/widget/cache-window.go:35 internal/widget/window-menu.go:96
 #: internal/widget/app-menu.ui:18
 #: data/com.github.rkoesters.xkcd-gtk.desktop.in:23
 msgid "Cache manager"
 msgstr ""
 
-#: internal/widget/cache-window.go:64
+#: internal/widget/cache-window.go:63
 msgid "Cached comic images"
 msgstr ""
 
-#: internal/widget/cache-window.go:58
+#: internal/widget/cache-window.go:57
 msgid "Cached comic metadata"
 msgstr ""
 
@@ -121,7 +121,7 @@ msgstr "Donker thema voor de late avonduurtjes"
 msgid "Date"
 msgstr "Datum"
 
-#: internal/widget/cache-window.go:77
+#: internal/widget/cache-window.go:76
 msgid "Download all comic images"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -283,7 +283,7 @@ msgstr "Donker thema aan/uit"
 msgid "Transcript"
 msgstr "Transcriptie"
 
-#: internal/widget/search-menu.go:73
+#: internal/widget/search-menu.go:66
 msgid "Updating comic search index..."
 msgstr "Bezig met bijwerken van zoekindex…"
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -24,12 +24,12 @@ msgstr ""
 "Een eenvoudige toepassing om de xkcd-strip te lezen, geschreven in Go en "
 "GTK+3"
 
-#: internal/widget/window-menu.go:125 internal/widget/app-menu.ui:40
+#: internal/widget/window-menu.go:130 internal/widget/app-menu.ui:46
 #: data/com.github.rkoesters.xkcd-gtk.desktop.in:31
 msgid "About"
 msgstr "Over"
 
-#: internal/widget/window-menu.go:108 internal/widget/app-menu.ui:30
+#: internal/widget/window-menu.go:117 internal/widget/app-menu.ui:36
 msgid "About xkcd"
 msgstr "Over xkcd"
 
@@ -57,8 +57,9 @@ msgstr "Bladwijzers"
 msgid "Cache comics for later offline viewing"
 msgstr "Sla verhalen op voor offline weergave"
 
-#: internal/widget/cache-window.go:36 internal/widget/window-menu.go:121
-#: data/com.github.rkoesters.xkcd-gtk.desktop.in:27
+#: internal/widget/cache-window.go:36 internal/widget/window-menu.go:96
+#: internal/widget/app-menu.ui:18
+#: data/com.github.rkoesters.xkcd-gtk.desktop.in:23
 msgid "Cache manager"
 msgstr ""
 
@@ -168,9 +169,9 @@ msgstr "Afbeelding"
 msgid "Keep track of comics with bookmarks"
 msgstr "Orden verhalen middels bladwijzers"
 
-#: internal/widget/window-menu.go:117 internal/widget/app-menu.ui:36
+#: internal/widget/window-menu.go:126 internal/widget/app-menu.ui:42
 #: internal/widget/shortcuts-window.ui:4
-#: data/com.github.rkoesters.xkcd-gtk.desktop.in:23
+#: data/com.github.rkoesters.xkcd-gtk.desktop.in:27
 msgid "Keyboard shortcuts"
 msgstr "Sneltoetsen"
 
@@ -236,7 +237,7 @@ msgstr "Eigenschappen"
 msgid "Quickly access comic explainations via the explain xkcd wiki"
 msgstr "Toon de uitleg van verhalen middels de ‘explain xkcd’-wiki"
 
-#: internal/widget/app-menu.ui:44
+#: internal/widget/app-menu.ui:50
 msgid "Quit"
 msgstr "Afsluiten"
 
@@ -286,7 +287,7 @@ msgstr "Transcriptie"
 msgid "View comic metadata"
 msgstr "Toon de metagegevens"
 
-#: internal/widget/window-menu.go:96 internal/widget/app-menu.ui:18
+#: internal/widget/window-menu.go:105 internal/widget/app-menu.ui:24
 msgid "What If?"
 msgstr "Wat als…?"
 
@@ -314,11 +315,11 @@ msgstr "Uitzoomen"
 msgid "webcomic;romance;sarcasm;math;language;"
 msgstr "online;strip;romantiek;sarcasme;wiskunde;taal;"
 
-#: internal/widget/window-menu.go:100 internal/widget/app-menu.ui:22
+#: internal/widget/window-menu.go:109 internal/widget/app-menu.ui:28
 msgid "xkcd blog"
 msgstr "xkcd-blog"
 
-#: internal/widget/window-menu.go:104 internal/widget/app-menu.ui:26
+#: internal/widget/window-menu.go:113 internal/widget/app-menu.ui:32
 msgid "xkcd books"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -57,17 +57,17 @@ msgstr "Bladwijzers"
 msgid "Cache comics for later offline viewing"
 msgstr "Sla verhalen op voor offline weergave"
 
-#: internal/widget/cache-window.go:29 internal/widget/window-menu.go:96
+#: internal/widget/cache-window.go:34 internal/widget/window-menu.go:96
 #: internal/widget/app-menu.ui:18
 #: data/com.github.rkoesters.xkcd-gtk.desktop.in:23
 msgid "Cache manager"
 msgstr ""
 
-#: internal/widget/cache-window.go:57
+#: internal/widget/cache-window.go:62
 msgid "Cached comic images"
 msgstr ""
 
-#: internal/widget/cache-window.go:51
+#: internal/widget/cache-window.go:56
 msgid "Cached comic metadata"
 msgstr ""
 
@@ -121,7 +121,7 @@ msgstr "Donker thema voor de late avonduurtjes"
 msgid "Date"
 msgstr "Datum"
 
-#: internal/widget/cache-window.go:70
+#: internal/widget/cache-window.go:77
 msgid "Download all comic images"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -57,8 +57,8 @@ msgstr "Bladwijzers"
 msgid "Cache comics for later offline viewing"
 msgstr "Sla verhalen op voor offline weergave"
 
-#: internal/widget/cache-window.go:34 internal/widget/window-menu.go:96
-#: internal/widget/app-menu.ui:18
+#: internal/widget/cache-window.go:34 internal/widget/window-menu.go:86
+#: internal/widget/app-menu.ui:12
 #: data/com.github.rkoesters.xkcd-gtk.desktop.in:23
 msgid "Cache manager"
 msgstr ""
@@ -274,7 +274,7 @@ msgstr "Zoek naar specifieke verhalen"
 msgid "Title"
 msgstr "Titel"
 
-#: internal/widget/dark-mode-switch.go:42 internal/widget/app-menu.ui:12
+#: internal/widget/dark-mode-switch.go:42 internal/widget/app-menu.ui:18
 #: internal/widget/shortcuts-window.ui:156
 msgid "Toggle dark mode"
 msgstr "Donker thema aan/uit"

--- a/po/nl.po
+++ b/po/nl.po
@@ -57,16 +57,16 @@ msgstr "Bladwijzers"
 msgid "Cache comics for later offline viewing"
 msgstr "Sla verhalen op voor offline weergave"
 
-#: internal/widget/cache-window.go:32 internal/widget/window-menu.go:121
+#: internal/widget/cache-window.go:36 internal/widget/window-menu.go:121
 #: data/com.github.rkoesters.xkcd-gtk.desktop.in:27
 msgid "Cache manager"
 msgstr ""
 
-#: internal/widget/cache-window.go:54
+#: internal/widget/cache-window.go:64
 msgid "Cached comic images"
 msgstr ""
 
-#: internal/widget/cache-window.go:49
+#: internal/widget/cache-window.go:58
 msgid "Cached comic metadata"
 msgstr ""
 
@@ -119,6 +119,10 @@ msgstr "Donker thema voor de late avonduurtjes"
 #: internal/widget/properties-dialog.go:124
 msgid "Date"
 msgstr "Datum"
+
+#: internal/widget/cache-window.go:77
+msgid "Download all comic images"
+msgstr ""
 
 #: internal/cache/cache.go:65
 msgid "Error reading local comic database"

--- a/po/nl.po
+++ b/po/nl.po
@@ -57,17 +57,17 @@ msgstr "Bladwijzers"
 msgid "Cache comics for later offline viewing"
 msgstr "Sla verhalen op voor offline weergave"
 
-#: internal/widget/cache-window.go:34 internal/widget/window-menu.go:86
+#: internal/widget/cache-window.go:37 internal/widget/window-menu.go:86
 #: internal/widget/app-menu.ui:12
 #: data/com.github.rkoesters.xkcd-gtk.desktop.in:23
 msgid "Cache manager"
 msgstr ""
 
-#: internal/widget/cache-window.go:62
+#: internal/widget/cache-window.go:65
 msgid "Cached comic images"
 msgstr ""
 
-#: internal/widget/cache-window.go:56
+#: internal/widget/cache-window.go:59
 msgid "Cached comic metadata"
 msgstr ""
 
@@ -121,7 +121,7 @@ msgstr "Donker thema voor de late avonduurtjes"
 msgid "Date"
 msgstr "Datum"
 
-#: internal/widget/cache-window.go:77
+#: internal/widget/cache-window.go:80
 msgid "Download all comic images"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -79,7 +79,7 @@ msgstr "Bezig met zoeken naar nieuw verhaal…"
 msgid "Close window"
 msgstr ""
 
-#: internal/widget/application.go:10
+#: internal/widget/application.go:11
 #: data/com.github.rkoesters.xkcd-gtk.desktop.in:5
 #: data/com.github.rkoesters.xkcd-gtk.appdata.xml.in:10
 msgid "Comic Sticks"

--- a/po/nl.po
+++ b/po/nl.po
@@ -196,7 +196,7 @@ msgstr "Nieuw venster"
 msgid "News"
 msgstr "Nieuws"
 
-#: internal/widget/search-menu.go:71
+#: internal/widget/search-menu.go:79
 msgid "No results found"
 msgstr "Er zijn geen zoekresultaten"
 
@@ -262,7 +262,7 @@ msgstr "Oorspronkelijk zoomniveau"
 msgid "Search"
 msgstr "Zoeken"
 
-#: internal/widget/search-menu.go:38 internal/widget/shortcuts-window.ui:83
+#: internal/widget/search-menu.go:40 internal/widget/shortcuts-window.ui:83
 msgid "Search comics"
 msgstr "Verhalen doorzoeken"
 
@@ -282,6 +282,10 @@ msgstr "Donker thema aan/uit"
 #: internal/widget/properties-dialog.go:144
 msgid "Transcript"
 msgstr "Transcriptie"
+
+#: internal/widget/search-menu.go:73
+msgid "Updating comic search index..."
+msgstr "Bezig met bijwerken van zoekindex…"
 
 #: data/com.github.rkoesters.xkcd-gtk.appdata.xml.in:20
 msgid "View comic metadata"
@@ -325,9 +329,6 @@ msgstr ""
 
 #~ msgid "Search Index Update"
 #~ msgstr "Zoekindex bijwerken"
-
-#~ msgid "Updating comic search index..."
-#~ msgstr "Bezig met bijwerken van zoekindex…"
 
 #~ msgid "xkcd store"
 #~ msgstr "xkcd-winkel"

--- a/po/pt.po
+++ b/po/pt.po
@@ -79,7 +79,7 @@ msgstr "A pesquisar por uma nova banda desenhada..."
 msgid "Close window"
 msgstr ""
 
-#: internal/widget/application.go:10
+#: internal/widget/application.go:11
 #: data/com.github.rkoesters.xkcd-gtk.desktop.in:5
 #: data/com.github.rkoesters.xkcd-gtk.appdata.xml.in:10
 msgid "Comic Sticks"

--- a/po/pt.po
+++ b/po/pt.po
@@ -197,7 +197,7 @@ msgstr "Nova Janela"
 msgid "News"
 msgstr "Noticias"
 
-#: internal/widget/search-menu.go:71
+#: internal/widget/search-menu.go:79
 msgid "No results found"
 msgstr "Nenhum resultado encontrado"
 
@@ -266,7 +266,7 @@ msgstr ""
 msgid "Search"
 msgstr "Procurar"
 
-#: internal/widget/search-menu.go:38 internal/widget/shortcuts-window.ui:83
+#: internal/widget/search-menu.go:40 internal/widget/shortcuts-window.ui:83
 msgid "Search comics"
 msgstr "Procurar Bandas Desenhadas"
 
@@ -286,6 +286,10 @@ msgstr "Alternar modo escuro"
 #: internal/widget/properties-dialog.go:144
 msgid "Transcript"
 msgstr "Transcrição"
+
+#: internal/widget/search-menu.go:73
+msgid "Updating comic search index..."
+msgstr "A atualizar o índice de pesquisa da banda desenhada..."
 
 #: data/com.github.rkoesters.xkcd-gtk.appdata.xml.in:20
 msgid "View comic metadata"
@@ -329,9 +333,6 @@ msgstr ""
 
 #~ msgid "Search Index Update"
 #~ msgstr "Índice de Pesquisa Atualizado"
-
-#~ msgid "Updating comic search index..."
-#~ msgstr "A atualizar o índice de pesquisa da banda desenhada..."
 
 #~ msgid "xkcd store"
 #~ msgstr "Loja xkcd"

--- a/po/pt.po
+++ b/po/pt.po
@@ -22,8 +22,8 @@ msgstr ""
 msgid "A simple xkcd viewer written in Go using GTK+3"
 msgstr "Um leitor simples de xkcd escrito em Go e usando o GTK+3"
 
-#: internal/widget/window-menu.go:121 internal/widget/app-menu.ui:40
-#: data/com.github.rkoesters.xkcd-gtk.desktop.in:27
+#: internal/widget/window-menu.go:125 internal/widget/app-menu.ui:40
+#: data/com.github.rkoesters.xkcd-gtk.desktop.in:31
 msgid "About"
 msgstr "Sobre"
 
@@ -56,6 +56,19 @@ msgid "Cache comics for later offline viewing"
 msgstr ""
 "Cache dos livros de banda desenhada para os visualizar mais tarde em modo "
 "offline"
+
+#: internal/widget/cache-window.go:32 internal/widget/window-menu.go:121
+#: data/com.github.rkoesters.xkcd-gtk.desktop.in:27
+msgid "Cache manager"
+msgstr ""
+
+#: internal/widget/cache-window.go:54
+msgid "Cached comic images"
+msgstr ""
+
+#: internal/widget/cache-window.go:49
+msgid "Cached comic metadata"
+msgstr ""
 
 #: internal/widget/application-window.go:290
 msgid "Checking for new comic..."
@@ -248,10 +261,6 @@ msgstr ""
 msgid "Search"
 msgstr "Procurar"
 
-#: internal/search/index.go:71
-msgid "Search Index Update"
-msgstr "Índice de Pesquisa Atualizado"
-
 #: internal/widget/search-menu.go:38 internal/widget/shortcuts-window.ui:83
 msgid "Search comics"
 msgstr "Procurar Bandas Desenhadas"
@@ -272,10 +281,6 @@ msgstr "Alternar modo escuro"
 #: internal/widget/properties-dialog.go:144
 msgid "Transcript"
 msgstr "Transcrição"
-
-#: internal/search/index.go:79
-msgid "Updating comic search index..."
-msgstr "A atualizar o índice de pesquisa da banda desenhada..."
 
 #: data/com.github.rkoesters.xkcd-gtk.appdata.xml.in:20
 msgid "View comic metadata"
@@ -316,6 +321,12 @@ msgstr "Blogue xkcd"
 #: internal/widget/window-menu.go:104 internal/widget/app-menu.ui:26
 msgid "xkcd books"
 msgstr ""
+
+#~ msgid "Search Index Update"
+#~ msgstr "Índice de Pesquisa Atualizado"
+
+#~ msgid "Updating comic search index..."
+#~ msgstr "A atualizar o índice de pesquisa da banda desenhada..."
 
 #~ msgid "xkcd store"
 #~ msgstr "Loja xkcd"

--- a/po/pt.po
+++ b/po/pt.po
@@ -57,16 +57,16 @@ msgstr ""
 "Cache dos livros de banda desenhada para os visualizar mais tarde em modo "
 "offline"
 
-#: internal/widget/cache-window.go:32 internal/widget/window-menu.go:121
+#: internal/widget/cache-window.go:36 internal/widget/window-menu.go:121
 #: data/com.github.rkoesters.xkcd-gtk.desktop.in:27
 msgid "Cache manager"
 msgstr ""
 
-#: internal/widget/cache-window.go:54
+#: internal/widget/cache-window.go:64
 msgid "Cached comic images"
 msgstr ""
 
-#: internal/widget/cache-window.go:49
+#: internal/widget/cache-window.go:58
 msgid "Cached comic metadata"
 msgstr ""
 
@@ -120,6 +120,10 @@ msgstr "Modo escuro para leitura à noite"
 #: internal/widget/properties-dialog.go:124
 msgid "Date"
 msgstr "Data"
+
+#: internal/widget/cache-window.go:77
+msgid "Download all comic images"
+msgstr ""
 
 #: internal/cache/cache.go:65
 msgid "Error reading local comic database"

--- a/po/pt.po
+++ b/po/pt.po
@@ -57,8 +57,8 @@ msgstr ""
 "Cache dos livros de banda desenhada para os visualizar mais tarde em modo "
 "offline"
 
-#: internal/widget/cache-window.go:34 internal/widget/window-menu.go:96
-#: internal/widget/app-menu.ui:18
+#: internal/widget/cache-window.go:34 internal/widget/window-menu.go:86
+#: internal/widget/app-menu.ui:12
 #: data/com.github.rkoesters.xkcd-gtk.desktop.in:23
 msgid "Cache manager"
 msgstr ""
@@ -278,7 +278,7 @@ msgstr "Procurar por Bandas Desenhadas"
 msgid "Title"
 msgstr "Título"
 
-#: internal/widget/dark-mode-switch.go:42 internal/widget/app-menu.ui:12
+#: internal/widget/dark-mode-switch.go:42 internal/widget/app-menu.ui:18
 #: internal/widget/shortcuts-window.ui:156
 msgid "Toggle dark mode"
 msgstr "Alternar modo escuro"

--- a/po/pt.po
+++ b/po/pt.po
@@ -57,17 +57,17 @@ msgstr ""
 "Cache dos livros de banda desenhada para os visualizar mais tarde em modo "
 "offline"
 
-#: internal/widget/cache-window.go:35 internal/widget/window-menu.go:96
+#: internal/widget/cache-window.go:29 internal/widget/window-menu.go:96
 #: internal/widget/app-menu.ui:18
 #: data/com.github.rkoesters.xkcd-gtk.desktop.in:23
 msgid "Cache manager"
 msgstr ""
 
-#: internal/widget/cache-window.go:63
+#: internal/widget/cache-window.go:57
 msgid "Cached comic images"
 msgstr ""
 
-#: internal/widget/cache-window.go:57
+#: internal/widget/cache-window.go:51
 msgid "Cached comic metadata"
 msgstr ""
 
@@ -122,7 +122,7 @@ msgstr "Modo escuro para leitura à noite"
 msgid "Date"
 msgstr "Data"
 
-#: internal/widget/cache-window.go:76
+#: internal/widget/cache-window.go:70
 msgid "Download all comic images"
 msgstr ""
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -287,7 +287,7 @@ msgstr "Alternar modo escuro"
 msgid "Transcript"
 msgstr "Transcrição"
 
-#: internal/widget/search-menu.go:73
+#: internal/widget/search-menu.go:66
 msgid "Updating comic search index..."
 msgstr "A atualizar o índice de pesquisa da banda desenhada..."
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -57,17 +57,17 @@ msgstr ""
 "Cache dos livros de banda desenhada para os visualizar mais tarde em modo "
 "offline"
 
-#: internal/widget/cache-window.go:29 internal/widget/window-menu.go:96
+#: internal/widget/cache-window.go:34 internal/widget/window-menu.go:96
 #: internal/widget/app-menu.ui:18
 #: data/com.github.rkoesters.xkcd-gtk.desktop.in:23
 msgid "Cache manager"
 msgstr ""
 
-#: internal/widget/cache-window.go:57
+#: internal/widget/cache-window.go:62
 msgid "Cached comic images"
 msgstr ""
 
-#: internal/widget/cache-window.go:51
+#: internal/widget/cache-window.go:56
 msgid "Cached comic metadata"
 msgstr ""
 
@@ -122,7 +122,7 @@ msgstr "Modo escuro para leitura à noite"
 msgid "Date"
 msgstr "Data"
 
-#: internal/widget/cache-window.go:70
+#: internal/widget/cache-window.go:77
 msgid "Download all comic images"
 msgstr ""
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -22,12 +22,12 @@ msgstr ""
 msgid "A simple xkcd viewer written in Go using GTK+3"
 msgstr "Um leitor simples de xkcd escrito em Go e usando o GTK+3"
 
-#: internal/widget/window-menu.go:125 internal/widget/app-menu.ui:40
+#: internal/widget/window-menu.go:130 internal/widget/app-menu.ui:46
 #: data/com.github.rkoesters.xkcd-gtk.desktop.in:31
 msgid "About"
 msgstr "Sobre"
 
-#: internal/widget/window-menu.go:108 internal/widget/app-menu.ui:30
+#: internal/widget/window-menu.go:117 internal/widget/app-menu.ui:36
 msgid "About xkcd"
 msgstr "Sobre o xkcd"
 
@@ -57,8 +57,9 @@ msgstr ""
 "Cache dos livros de banda desenhada para os visualizar mais tarde em modo "
 "offline"
 
-#: internal/widget/cache-window.go:36 internal/widget/window-menu.go:121
-#: data/com.github.rkoesters.xkcd-gtk.desktop.in:27
+#: internal/widget/cache-window.go:36 internal/widget/window-menu.go:96
+#: internal/widget/app-menu.ui:18
+#: data/com.github.rkoesters.xkcd-gtk.desktop.in:23
 msgid "Cache manager"
 msgstr ""
 
@@ -169,9 +170,9 @@ msgstr "Imagem"
 msgid "Keep track of comics with bookmarks"
 msgstr "Mantenha o controlo de bandas desenhadas com os marcadores"
 
-#: internal/widget/window-menu.go:117 internal/widget/app-menu.ui:36
+#: internal/widget/window-menu.go:126 internal/widget/app-menu.ui:42
 #: internal/widget/shortcuts-window.ui:4
-#: data/com.github.rkoesters.xkcd-gtk.desktop.in:23
+#: data/com.github.rkoesters.xkcd-gtk.desktop.in:27
 msgid "Keyboard shortcuts"
 msgstr "Atalhos de Teclado"
 
@@ -238,7 +239,7 @@ msgid "Quickly access comic explainations via the explain xkcd wiki"
 msgstr ""
 "Acessa rapidamente as explicações de bandas desenhadas a partir da wiki xkcd"
 
-#: internal/widget/app-menu.ui:44
+#: internal/widget/app-menu.ui:50
 msgid "Quit"
 msgstr "Sair"
 
@@ -290,7 +291,7 @@ msgstr "Transcrição"
 msgid "View comic metadata"
 msgstr "Ver a meta data da banda desenhada"
 
-#: internal/widget/window-menu.go:96 internal/widget/app-menu.ui:18
+#: internal/widget/window-menu.go:105 internal/widget/app-menu.ui:24
 msgid "What If?"
 msgstr "E se?"
 
@@ -318,11 +319,11 @@ msgstr ""
 msgid "webcomic;romance;sarcasm;math;language;"
 msgstr "banda desenhada;romance;sarcasmo;matemática;linguagem;"
 
-#: internal/widget/window-menu.go:100 internal/widget/app-menu.ui:22
+#: internal/widget/window-menu.go:109 internal/widget/app-menu.ui:28
 msgid "xkcd blog"
 msgstr "Blogue xkcd"
 
-#: internal/widget/window-menu.go:104 internal/widget/app-menu.ui:26
+#: internal/widget/window-menu.go:113 internal/widget/app-menu.ui:32
 msgid "xkcd books"
 msgstr ""
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -57,17 +57,17 @@ msgstr ""
 "Cache dos livros de banda desenhada para os visualizar mais tarde em modo "
 "offline"
 
-#: internal/widget/cache-window.go:36 internal/widget/window-menu.go:96
+#: internal/widget/cache-window.go:35 internal/widget/window-menu.go:96
 #: internal/widget/app-menu.ui:18
 #: data/com.github.rkoesters.xkcd-gtk.desktop.in:23
 msgid "Cache manager"
 msgstr ""
 
-#: internal/widget/cache-window.go:64
+#: internal/widget/cache-window.go:63
 msgid "Cached comic images"
 msgstr ""
 
-#: internal/widget/cache-window.go:58
+#: internal/widget/cache-window.go:57
 msgid "Cached comic metadata"
 msgstr ""
 
@@ -122,7 +122,7 @@ msgstr "Modo escuro para leitura à noite"
 msgid "Date"
 msgstr "Data"
 
-#: internal/widget/cache-window.go:77
+#: internal/widget/cache-window.go:76
 msgid "Download all comic images"
 msgstr ""
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -57,17 +57,17 @@ msgstr ""
 "Cache dos livros de banda desenhada para os visualizar mais tarde em modo "
 "offline"
 
-#: internal/widget/cache-window.go:34 internal/widget/window-menu.go:86
+#: internal/widget/cache-window.go:37 internal/widget/window-menu.go:86
 #: internal/widget/app-menu.ui:12
 #: data/com.github.rkoesters.xkcd-gtk.desktop.in:23
 msgid "Cache manager"
 msgstr ""
 
-#: internal/widget/cache-window.go:62
+#: internal/widget/cache-window.go:65
 msgid "Cached comic images"
 msgstr ""
 
-#: internal/widget/cache-window.go:56
+#: internal/widget/cache-window.go:59
 msgid "Cached comic metadata"
 msgstr ""
 
@@ -122,7 +122,7 @@ msgstr "Modo escuro para leitura à noite"
 msgid "Date"
 msgstr "Data"
 
-#: internal/widget/cache-window.go:77
+#: internal/widget/cache-window.go:80
 msgid "Download all comic images"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -57,17 +57,17 @@ msgstr "Yer imleri"
 msgid "Cache comics for later offline viewing"
 msgstr "Karikatürleri daha sonra çevrimdışı görüntülemek için önbelleğe al"
 
-#: internal/widget/cache-window.go:29 internal/widget/window-menu.go:96
+#: internal/widget/cache-window.go:34 internal/widget/window-menu.go:96
 #: internal/widget/app-menu.ui:18
 #: data/com.github.rkoesters.xkcd-gtk.desktop.in:23
 msgid "Cache manager"
 msgstr ""
 
-#: internal/widget/cache-window.go:57
+#: internal/widget/cache-window.go:62
 msgid "Cached comic images"
 msgstr ""
 
-#: internal/widget/cache-window.go:51
+#: internal/widget/cache-window.go:56
 msgid "Cached comic metadata"
 msgstr ""
 
@@ -121,7 +121,7 @@ msgstr "Gece geç saatlerde okumak için koyu kip"
 msgid "Date"
 msgstr "Tarih"
 
-#: internal/widget/cache-window.go:70
+#: internal/widget/cache-window.go:77
 msgid "Download all comic images"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -57,16 +57,16 @@ msgstr "Yer imleri"
 msgid "Cache comics for later offline viewing"
 msgstr "Karikatürleri daha sonra çevrimdışı görüntülemek için önbelleğe al"
 
-#: internal/widget/cache-window.go:32 internal/widget/window-menu.go:121
+#: internal/widget/cache-window.go:36 internal/widget/window-menu.go:121
 #: data/com.github.rkoesters.xkcd-gtk.desktop.in:27
 msgid "Cache manager"
 msgstr ""
 
-#: internal/widget/cache-window.go:54
+#: internal/widget/cache-window.go:64
 msgid "Cached comic images"
 msgstr ""
 
-#: internal/widget/cache-window.go:49
+#: internal/widget/cache-window.go:58
 msgid "Cached comic metadata"
 msgstr ""
 
@@ -119,6 +119,10 @@ msgstr "Gece geç saatlerde okumak için koyu kip"
 #: internal/widget/properties-dialog.go:124
 msgid "Date"
 msgstr "Tarih"
+
+#: internal/widget/cache-window.go:77
+msgid "Download all comic images"
+msgstr ""
 
 #: internal/cache/cache.go:65
 msgid "Error reading local comic database"

--- a/po/tr.po
+++ b/po/tr.po
@@ -57,8 +57,8 @@ msgstr "Yer imleri"
 msgid "Cache comics for later offline viewing"
 msgstr "Karikatürleri daha sonra çevrimdışı görüntülemek için önbelleğe al"
 
-#: internal/widget/cache-window.go:34 internal/widget/window-menu.go:96
-#: internal/widget/app-menu.ui:18
+#: internal/widget/cache-window.go:34 internal/widget/window-menu.go:86
+#: internal/widget/app-menu.ui:12
 #: data/com.github.rkoesters.xkcd-gtk.desktop.in:23
 msgid "Cache manager"
 msgstr ""
@@ -275,7 +275,7 @@ msgstr "Karikatür ara"
 msgid "Title"
 msgstr "Başlık"
 
-#: internal/widget/dark-mode-switch.go:42 internal/widget/app-menu.ui:12
+#: internal/widget/dark-mode-switch.go:42 internal/widget/app-menu.ui:18
 #: internal/widget/shortcuts-window.ui:156
 msgid "Toggle dark mode"
 msgstr "Koyu kipi aç/kapat"

--- a/po/tr.po
+++ b/po/tr.po
@@ -79,7 +79,7 @@ msgstr "Yeni karikatür denetleniyor..."
 msgid "Close window"
 msgstr "Pencereyi kapat"
 
-#: internal/widget/application.go:10
+#: internal/widget/application.go:11
 #: data/com.github.rkoesters.xkcd-gtk.desktop.in:5
 #: data/com.github.rkoesters.xkcd-gtk.appdata.xml.in:10
 msgid "Comic Sticks"

--- a/po/tr.po
+++ b/po/tr.po
@@ -57,17 +57,17 @@ msgstr "Yer imleri"
 msgid "Cache comics for later offline viewing"
 msgstr "Karikatürleri daha sonra çevrimdışı görüntülemek için önbelleğe al"
 
-#: internal/widget/cache-window.go:34 internal/widget/window-menu.go:86
+#: internal/widget/cache-window.go:37 internal/widget/window-menu.go:86
 #: internal/widget/app-menu.ui:12
 #: data/com.github.rkoesters.xkcd-gtk.desktop.in:23
 msgid "Cache manager"
 msgstr ""
 
-#: internal/widget/cache-window.go:62
+#: internal/widget/cache-window.go:65
 msgid "Cached comic images"
 msgstr ""
 
-#: internal/widget/cache-window.go:56
+#: internal/widget/cache-window.go:59
 msgid "Cached comic metadata"
 msgstr ""
 
@@ -121,7 +121,7 @@ msgstr "Gece geç saatlerde okumak için koyu kip"
 msgid "Date"
 msgstr "Tarih"
 
-#: internal/widget/cache-window.go:77
+#: internal/widget/cache-window.go:80
 msgid "Download all comic images"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -196,7 +196,7 @@ msgstr "Yeni pencere"
 msgid "News"
 msgstr "Haberler"
 
-#: internal/widget/search-menu.go:71
+#: internal/widget/search-menu.go:79
 msgid "No results found"
 msgstr "Sonuç bulunamadı"
 
@@ -263,7 +263,7 @@ msgstr "Yakınlaştırmayı sıfırla"
 msgid "Search"
 msgstr "Ara"
 
-#: internal/widget/search-menu.go:38 internal/widget/shortcuts-window.ui:83
+#: internal/widget/search-menu.go:40 internal/widget/shortcuts-window.ui:83
 msgid "Search comics"
 msgstr "Karikatür ara"
 
@@ -284,6 +284,10 @@ msgstr "Koyu kipi aç/kapat"
 #: internal/widget/properties-dialog.go:144
 msgid "Transcript"
 msgstr "Yazılı metin"
+
+#: internal/widget/search-menu.go:73
+msgid "Updating comic search index..."
+msgstr "Karikatür arama dizini güncelleniyor..."
 
 #: data/com.github.rkoesters.xkcd-gtk.appdata.xml.in:20
 msgid "View comic metadata"
@@ -327,6 +331,3 @@ msgstr "xkcd kitapları"
 
 #~ msgid "Search Index Update"
 #~ msgstr "Arama Dizini Güncellemesi"
-
-#~ msgid "Updating comic search index..."
-#~ msgstr "Karikatür arama dizini güncelleniyor..."

--- a/po/tr.po
+++ b/po/tr.po
@@ -24,8 +24,8 @@ msgstr ""
 msgid "A simple xkcd viewer written in Go using GTK+3"
 msgstr "Go dili ve GTK+3 kullanılarak yazılmış basit xkcd görüntüleyici"
 
-#: internal/widget/window-menu.go:121 internal/widget/app-menu.ui:40
-#: data/com.github.rkoesters.xkcd-gtk.desktop.in:27
+#: internal/widget/window-menu.go:125 internal/widget/app-menu.ui:40
+#: data/com.github.rkoesters.xkcd-gtk.desktop.in:31
 msgid "About"
 msgstr "Hakkında"
 
@@ -56,6 +56,19 @@ msgstr "Yer imleri"
 #: data/com.github.rkoesters.xkcd-gtk.appdata.xml.in:18
 msgid "Cache comics for later offline viewing"
 msgstr "Karikatürleri daha sonra çevrimdışı görüntülemek için önbelleğe al"
+
+#: internal/widget/cache-window.go:32 internal/widget/window-menu.go:121
+#: data/com.github.rkoesters.xkcd-gtk.desktop.in:27
+msgid "Cache manager"
+msgstr ""
+
+#: internal/widget/cache-window.go:54
+msgid "Cached comic images"
+msgstr ""
+
+#: internal/widget/cache-window.go:49
+msgid "Cached comic metadata"
+msgstr ""
 
 #: internal/widget/application-window.go:290
 msgid "Checking for new comic..."
@@ -245,10 +258,6 @@ msgstr "Yakınlaştırmayı sıfırla"
 msgid "Search"
 msgstr "Ara"
 
-#: internal/search/index.go:71
-msgid "Search Index Update"
-msgstr "Arama Dizini Güncellemesi"
-
 #: internal/widget/search-menu.go:38 internal/widget/shortcuts-window.ui:83
 msgid "Search comics"
 msgstr "Karikatür ara"
@@ -270,10 +279,6 @@ msgstr "Koyu kipi aç/kapat"
 #: internal/widget/properties-dialog.go:144
 msgid "Transcript"
 msgstr "Yazılı metin"
-
-#: internal/search/index.go:79
-msgid "Updating comic search index..."
-msgstr "Karikatür arama dizini güncelleniyor..."
 
 #: data/com.github.rkoesters.xkcd-gtk.appdata.xml.in:20
 msgid "View comic metadata"
@@ -314,3 +319,9 @@ msgstr "xkcd günlüğü"
 #: internal/widget/window-menu.go:104 internal/widget/app-menu.ui:26
 msgid "xkcd books"
 msgstr "xkcd kitapları"
+
+#~ msgid "Search Index Update"
+#~ msgstr "Arama Dizini Güncellemesi"
+
+#~ msgid "Updating comic search index..."
+#~ msgstr "Karikatür arama dizini güncelleniyor..."

--- a/po/tr.po
+++ b/po/tr.po
@@ -57,17 +57,17 @@ msgstr "Yer imleri"
 msgid "Cache comics for later offline viewing"
 msgstr "Karikatürleri daha sonra çevrimdışı görüntülemek için önbelleğe al"
 
-#: internal/widget/cache-window.go:35 internal/widget/window-menu.go:96
+#: internal/widget/cache-window.go:29 internal/widget/window-menu.go:96
 #: internal/widget/app-menu.ui:18
 #: data/com.github.rkoesters.xkcd-gtk.desktop.in:23
 msgid "Cache manager"
 msgstr ""
 
-#: internal/widget/cache-window.go:63
+#: internal/widget/cache-window.go:57
 msgid "Cached comic images"
 msgstr ""
 
-#: internal/widget/cache-window.go:57
+#: internal/widget/cache-window.go:51
 msgid "Cached comic metadata"
 msgstr ""
 
@@ -121,7 +121,7 @@ msgstr "Gece geç saatlerde okumak için koyu kip"
 msgid "Date"
 msgstr "Tarih"
 
-#: internal/widget/cache-window.go:76
+#: internal/widget/cache-window.go:70
 msgid "Download all comic images"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -285,7 +285,7 @@ msgstr "Koyu kipi aç/kapat"
 msgid "Transcript"
 msgstr "Yazılı metin"
 
-#: internal/widget/search-menu.go:73
+#: internal/widget/search-menu.go:66
 msgid "Updating comic search index..."
 msgstr "Karikatür arama dizini güncelleniyor..."
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -57,17 +57,17 @@ msgstr "Yer imleri"
 msgid "Cache comics for later offline viewing"
 msgstr "Karikatürleri daha sonra çevrimdışı görüntülemek için önbelleğe al"
 
-#: internal/widget/cache-window.go:36 internal/widget/window-menu.go:96
+#: internal/widget/cache-window.go:35 internal/widget/window-menu.go:96
 #: internal/widget/app-menu.ui:18
 #: data/com.github.rkoesters.xkcd-gtk.desktop.in:23
 msgid "Cache manager"
 msgstr ""
 
-#: internal/widget/cache-window.go:64
+#: internal/widget/cache-window.go:63
 msgid "Cached comic images"
 msgstr ""
 
-#: internal/widget/cache-window.go:58
+#: internal/widget/cache-window.go:57
 msgid "Cached comic metadata"
 msgstr ""
 
@@ -121,7 +121,7 @@ msgstr "Gece geç saatlerde okumak için koyu kip"
 msgid "Date"
 msgstr "Tarih"
 
-#: internal/widget/cache-window.go:77
+#: internal/widget/cache-window.go:76
 msgid "Download all comic images"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -24,12 +24,12 @@ msgstr ""
 msgid "A simple xkcd viewer written in Go using GTK+3"
 msgstr "Go dili ve GTK+3 kullanılarak yazılmış basit xkcd görüntüleyici"
 
-#: internal/widget/window-menu.go:125 internal/widget/app-menu.ui:40
+#: internal/widget/window-menu.go:130 internal/widget/app-menu.ui:46
 #: data/com.github.rkoesters.xkcd-gtk.desktop.in:31
 msgid "About"
 msgstr "Hakkında"
 
-#: internal/widget/window-menu.go:108 internal/widget/app-menu.ui:30
+#: internal/widget/window-menu.go:117 internal/widget/app-menu.ui:36
 msgid "About xkcd"
 msgstr "xkcd Hakkında"
 
@@ -57,8 +57,9 @@ msgstr "Yer imleri"
 msgid "Cache comics for later offline viewing"
 msgstr "Karikatürleri daha sonra çevrimdışı görüntülemek için önbelleğe al"
 
-#: internal/widget/cache-window.go:36 internal/widget/window-menu.go:121
-#: data/com.github.rkoesters.xkcd-gtk.desktop.in:27
+#: internal/widget/cache-window.go:36 internal/widget/window-menu.go:96
+#: internal/widget/app-menu.ui:18
+#: data/com.github.rkoesters.xkcd-gtk.desktop.in:23
 msgid "Cache manager"
 msgstr ""
 
@@ -168,9 +169,9 @@ msgstr "Görüntü"
 msgid "Keep track of comics with bookmarks"
 msgstr "Yer imleriyle karikatürleri takip edin"
 
-#: internal/widget/window-menu.go:117 internal/widget/app-menu.ui:36
+#: internal/widget/window-menu.go:126 internal/widget/app-menu.ui:42
 #: internal/widget/shortcuts-window.ui:4
-#: data/com.github.rkoesters.xkcd-gtk.desktop.in:23
+#: data/com.github.rkoesters.xkcd-gtk.desktop.in:27
 msgid "Keyboard shortcuts"
 msgstr "Klavye kısayolları"
 
@@ -236,7 +237,7 @@ msgstr "Özellikler"
 msgid "Quickly access comic explainations via the explain xkcd wiki"
 msgstr "xkcd wiki aracılığıyla karikatür açıklamalarına hızla erişin"
 
-#: internal/widget/app-menu.ui:44
+#: internal/widget/app-menu.ui:50
 msgid "Quit"
 msgstr "Çık"
 
@@ -288,7 +289,7 @@ msgstr "Yazılı metin"
 msgid "View comic metadata"
 msgstr "Karikatür üst verisini görüntüle"
 
-#: internal/widget/window-menu.go:96 internal/widget/app-menu.ui:18
+#: internal/widget/window-menu.go:105 internal/widget/app-menu.ui:24
 msgid "What If?"
 msgstr "Farzedelim?"
 
@@ -316,11 +317,11 @@ msgstr "Uzaklaştır"
 msgid "webcomic;romance;sarcasm;math;language;"
 msgstr "web çizgi roman;aşk;alaycılık;matematik;dil;"
 
-#: internal/widget/window-menu.go:100 internal/widget/app-menu.ui:22
+#: internal/widget/window-menu.go:109 internal/widget/app-menu.ui:28
 msgid "xkcd blog"
 msgstr "xkcd günlüğü"
 
-#: internal/widget/window-menu.go:104 internal/widget/app-menu.ui:26
+#: internal/widget/window-menu.go:113 internal/widget/app-menu.ui:32
 msgid "xkcd books"
 msgstr "xkcd kitapları"
 


### PR DESCRIPTION
Cache manager shows completeness of the cache and provides a button for proactively caching all comic images.

Removes "Search Index Update" dialog at startup, splitting the functionality into two separate locations:
* Search menu will state whether the index is rebuilding
* Cache manager will show the status of the index rebuild