### PR TITLE
data: Mark release descriptions as untranslatable

### DIFF
--- a/data/com.github.rkoesters.xkcd-gtk.appdata.xml.in
+++ b/data/com.github.rkoesters.xkcd-gtk.appdata.xml.in
@@ -58,12 +58,12 @@
 
   <releases>
     <release version="1.7.1" date="2023-03-19">
-      <description>
+      <description translatable="no">
         <p>Minor packaging fixes.</p>
       </description>
     </release>
     <release version="1.7.0" date="2023-03-19">
-      <description>
+      <description translatable="no">
         <p>Add the cache management window, allowing you to download all comic images in preparation for being offline.</p>
         <p>Add or remove bookmarks with one button click.</p>
         <p>Keyboard shortcut changes:</p>
@@ -75,7 +75,7 @@
       </description>
     </release>
     <release version="1.6.5" date="2022-07-31">
-      <description>
+      <description translatable="no">
         <p>Minor improvements:</p>
         <ul>
           <li>Overhaul search and bookmark menus to improve performance with large lists</li>
@@ -85,7 +85,7 @@
       </description>
     </release>
     <release version="1.6.4" date="2022-07-16">
-      <description>
+      <description translatable="no">
         <p>Add a couple new keyboard shortcuts and add some common aliases for existing keyboard shortcuts. Open the shortcuts window with ctrl+? to check out what's new!</p>
         <p>Other improvements:</p>
         <ul>
@@ -95,7 +95,7 @@
       </description>
     </release>
     <release version="1.6.3" date="2022-07-09">
-      <description>
+      <description translatable="no">
         <p>Minor improvements:</p>
         <ul>
           <li>Fix crash when closing window in desktop environments that show an app menu</li>
@@ -106,7 +106,7 @@
       </description>
     </release>
     <release version="1.6.2" date="2022-07-04">
-      <description>
+      <description translatable="no">
         <p>Minor improvements:</p>
         <ul>
           <li>Fix keyboard navigation for dark mode switch</li>
@@ -116,7 +116,7 @@
       </description>
     </release>
     <release version="1.6.1" date="2022-06-30">
-      <description>
+      <description translatable="no">
         <p>Minor improvements:</p>
         <ul>
           <li>The dark mode toggle in the window menu is now a switch</li>
@@ -128,7 +128,7 @@
       </description>
     </release>
     <release version="1.6.0" date="2022-06-20">
-      <description>
+      <description translatable="no">
         <p>The zoom update!</p>
         <ul>
           <li>Zoom in and out to get a better look at comics</li>
@@ -138,7 +138,7 @@
       </description>
     </release>
     <release version="1.5.3" date="2022-06-18">
-      <description>
+      <description translatable="no">
         <p>Minor fixes:</p>
         <ul>
           <li>Fixes and tweaks to app UI text and translations</li>
@@ -147,7 +147,7 @@
       </description>
     </release>
     <release version="1.5.2" date="2022-02-13">
-      <description>
+      <description translatable="no">
         <p>Minor fixes:</p>
         <ul>
           <li>Improve caching behavior of "Newest Comic" button</li>
@@ -157,7 +157,7 @@
       </description>
     </release>
     <release version="1.5.1" date="2021-10-23">
-      <description>
+      <description translatable="no">
         <p>Minor fixes:</p>
         <ul>
           <li>Fix a localization bug</li>
@@ -165,7 +165,7 @@
       </description>
     </release>
     <release version="1.5.0" date="2021-10-22">
-      <description>
+      <description translatable="no">
         <p>The context menu update!</p>
         <ul>
           <li>Add a context menu when right-clicking on a comic</li>
@@ -176,7 +176,7 @@
       </description>
     </release>
     <release version="1.4.4" date="2021-10-18">
-      <description>
+      <description translatable="no">
         <p>Minor fixes:</p>
         <ul>
           <li>Improve appearance of window menu, including shortcut hints where applicable</li>
@@ -185,7 +185,7 @@
       </description>
     </release>
     <release version="1.4.3" date="2021-10-16">
-      <description>
+      <description translatable="no">
         <p>Minor fixes:</p>
         <ul>
           <li>Minor performance improvements</li>
@@ -193,7 +193,7 @@
       </description>
     </release>
     <release version="1.4.2" date="2021-07-18">
-      <description>
+      <description translatable="no">
         <p>Minor fixes:</p>
         <ul>
           <li>Improve UI contrast in dark mode by always using symbolic icons while in dark mode</li>
@@ -202,12 +202,12 @@
       </description>
     </release>
     <release version="1.4.1" date="2021-07-17">
-      <description>
+      <description translatable="no">
         <p>Improve dark mode on elementary OS by making the title bar dark instead of pastel blue.</p>
       </description>
     </release>
     <release version="1.4.0" date="2021-06-09">
-      <description>
+      <description translatable="no">
         <p>Major fixes:</p>
         <ul>
           <li>Move the random comic button to sit between the other navigation buttons</li>
@@ -218,7 +218,7 @@
       </description>
     </release>
     <release version="1.3.4" date="2021-05-30">
-      <description>
+      <description translatable="no">
         <p>Minor fixes:</p>
         <ul>
           <li>Add Portuguese translations (Thanks to rottenpants466)</li>
@@ -229,7 +229,7 @@
       </description>
     </release>
     <release version="1.3.2" date="2020-02-08">
-      <description>
+      <description translatable="no">
         <p>Minor fixes:</p>
         <ul>
           <li>Add Italian translations (Thanks to albanobattistella)</li>
@@ -239,7 +239,7 @@
       </description>
     </release>
     <release version="1.3.1" date="2019-11-08">
-      <description>
+      <description translatable="no">
         <p>Minor fixes:</p>
         <ul>
           <li>Add loading icon while fetching comic</li>
@@ -248,7 +248,7 @@
       </description>
     </release>
     <release version="1.3.0" date="2019-05-11">
-      <description>
+      <description translatable="no">
         <p>The bookmarks update!</p>
         <ul>
           <li>Add bookmarks for keeping track of comics</li>
@@ -257,7 +257,7 @@
       </description>
     </release>
     <release version="1.2.0" date="2019-05-03">
-      <description>
+      <description translatable="no">
         <p>The localization update!</p>
         <ul>
           <li>Add support for translations (user interface only, comics will remain in their original language)</li>
@@ -266,17 +266,17 @@
       </description>
     </release>
     <release version="1.1.3" date="2019-01-14">
-      <description>
+      <description translatable="no">
         <p>Fix for changes to xkcd API encoding.</p>
       </description>
     </release>
     <release version="1.1.2" date="2018-11-16">
-      <description>
+      <description translatable="no">
         <p>Fix restoring of window state when maximized.</p>
       </description>
     </release>
     <release version="1.1.1" date="2018-11-04">
-      <description>
+      <description translatable="no">
         <p>Minor fixes:</p>
         <ul>
           <li>Add keyboard shortcut for dark mode</li>
@@ -285,7 +285,7 @@
       </description>
     </release>
     <release version="1.1.0" date="2018-10-30">
-      <description>
+      <description translatable="no">
         <p>The dark mode update!</p>
         <ul>
           <li>Add dark mode that inverts the comic image to improve readability in the dark</li>
@@ -296,17 +296,17 @@
       </description>
     </release>
     <release version="1.0.4" date="2018-10-22">
-      <description>
+      <description translatable="no">
         <p>Update app metadata to pass appstream-util validate-relax.</p>
       </description>
     </release>
     <release version="1.0.3" date="2018-10-21">
-      <description>
+      <description translatable="no">
         <p>Revert fuzzy searching due to regressions.</p>
       </description>
     </release>
     <release version="1.0.2" date="2018-10-21">
-      <description>
+      <description translatable="no">
         <p>Minor fixes:</p>
         <ul>
           <li>Use fuzzy searching</li>
@@ -315,12 +315,12 @@
       </description>
     </release>
     <release version="1.0.1" date="2018-10-19">
-      <description>
+      <description translatable="no">
         <p>Update OARS metadata.</p>
       </description>
     </release>
     <release version="1.0.0" date="2018-10-18">
-      <description>
+      <description translatable="no">
         <p>First stable release!</p>
         <ul>
           <li>Improve startup time</li>

--- a/po/com.github.rkoesters.xkcd-gtk.pot
+++ b/po/com.github.rkoesters.xkcd-gtk.pot
@@ -16,69 +16,14 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: internal/widget/about-dialog.go:19
-msgid "A simple xkcd viewer written in Go using GTK+3"
-msgstr ""
-
-#: internal/widget/window-menu.go:91 internal/widget/app-menu.ui:46
-#: data/com.github.rkoesters.xkcd-gtk.desktop.in:34
-msgid "About"
-msgstr ""
-
-#: internal/widget/window-menu.go:88 internal/widget/app-menu.ui:36
-msgid "About xkcd"
-msgstr ""
-
-#: internal/widget/bookmarks-menu.go:157
-msgid "Add to bookmarks"
-msgstr ""
-
-#: internal/widget/properties-dialog.go:97
-msgid "Alt text"
-msgstr ""
-
-#: internal/widget/shortcuts-window.ui:152
-msgid "Application"
-msgstr ""
-
-#: internal/widget/context-menu.go:30 internal/widget/shortcuts-window.ui:123
-msgid "Bookmark this comic"
-msgstr ""
-
-#: internal/widget/bookmarks-menu.go:59 internal/widget/shortcuts-window.ui:119
-msgid "Bookmarks"
-msgstr ""
-
-#: data/com.github.rkoesters.xkcd-gtk.appdata.xml.in:18
-msgid "Cache comics for later offline viewing"
-msgstr ""
-
-#: internal/widget/cache-window.go:38 internal/widget/window-menu.go:70
-#: internal/widget/app-menu.ui:12
-#: data/com.github.rkoesters.xkcd-gtk.desktop.in:24
-msgid "Cache manager"
-msgstr ""
-
-#: internal/widget/cache-window.go:77
-msgid "Cached comic images"
-msgstr ""
-
-#: internal/widget/cache-window.go:71
-msgid "Cached comic metadata"
-msgstr ""
-
-#: internal/widget/application-window.go:308
-msgid "Checking for new comic..."
-msgstr ""
-
-#: internal/widget/shortcuts-window.ui:22
-msgid "Close window"
-msgstr ""
-
-#: internal/widget/application.go:11
-#: data/com.github.rkoesters.xkcd-gtk.desktop.in:5
 #: data/com.github.rkoesters.xkcd-gtk.appdata.xml.in:10
+#: data/com.github.rkoesters.xkcd-gtk.desktop.in:5
 msgid "Comic Sticks"
+msgstr ""
+
+#: data/com.github.rkoesters.xkcd-gtk.appdata.xml.in:11
+#: data/com.github.rkoesters.xkcd-gtk.desktop.in:7
+msgid "Read xkcd: a webcomic of romance, sarcasm, math, and language"
 msgstr ""
 
 #: data/com.github.rkoesters.xkcd-gtk.appdata.xml.in:13
@@ -87,236 +32,182 @@ msgid ""
 "offline browsing, and intuitive keyboard shortcuts."
 msgstr ""
 
-#: internal/cache/cache.go:67
-msgid "Comic not found"
-msgstr ""
-
-#: internal/widget/application-window.go:384
-msgid "Connect to the internet to download comic image"
-msgstr ""
-
-#: internal/cache/cache.go:69
-msgid "Connect to the internet to download some comics!"
-msgstr ""
-
-#: internal/cache/cache.go:68
-msgid "Couldn't get comic"
-msgstr ""
-
-#: internal/widget/dark-mode-switch.go:54
-msgid "Dark mode"
-msgstr ""
-
-#: data/com.github.rkoesters.xkcd-gtk.appdata.xml.in:19
-msgid "Dark mode for late night reading"
-msgstr ""
-
-#: internal/widget/properties-dialog.go:89
-msgid "Date"
-msgstr ""
-
-#: internal/widget/cache-window.go:92
-msgid "Download all comic images"
-msgstr ""
-
-#: internal/cache/cache.go:66
-msgid "Error reading local comic database"
-msgstr ""
-
-#: internal/widget/context-menu.go:50 internal/widget/window-menu.go:53
-msgid "Explain"
-msgstr ""
-
 #: data/com.github.rkoesters.xkcd-gtk.appdata.xml.in:14
 msgid "Features:"
-msgstr ""
-
-#: internal/widget/shortcuts-window.ui:11
-msgid "General"
-msgstr ""
-
-#: internal/widget/navigation-bar.go:65 internal/widget/shortcuts-window.ui:70
-msgid "Go to a random comic"
-msgstr ""
-
-#: internal/widget/navigation-bar.go:55 internal/widget/shortcuts-window.ui:42
-msgid "Go to the first comic"
-msgstr ""
-
-#: internal/widget/navigation-bar.go:75 internal/widget/shortcuts-window.ui:63
-msgid "Go to the newest comic"
-msgstr ""
-
-#: internal/widget/navigation-bar.go:70 internal/widget/shortcuts-window.ui:56
-msgid "Go to the next comic"
-msgstr ""
-
-#: internal/widget/navigation-bar.go:60 internal/widget/shortcuts-window.ui:49
-msgid "Go to the previous comic"
-msgstr ""
-
-#: internal/widget/properties-dialog.go:93
-msgid "Image"
-msgstr ""
-
-#: data/com.github.rkoesters.xkcd-gtk.appdata.xml.in:17
-msgid "Keep track of comics with bookmarks"
-msgstr ""
-
-#: internal/widget/window-menu.go:90 internal/widget/app-menu.ui:42
-#: internal/widget/shortcuts-window.ui:4
-#: data/com.github.rkoesters.xkcd-gtk.desktop.in:29
-msgid "Keyboard shortcuts"
-msgstr ""
-
-#: internal/widget/properties-dialog.go:105
-msgid "Link"
-msgstr ""
-
-#: internal/widget/application-window.go:391
-msgid "Loading comic..."
-msgstr ""
-
-#: internal/widget/shortcuts-window.ui:38
-msgid "Navigate"
-msgstr ""
-
-#: internal/widget/window-menu.go:68 internal/widget/app-menu.ui:6
-#: data/com.github.rkoesters.xkcd-gtk.desktop.in:19
-msgid "New window"
-msgstr ""
-
-#: internal/widget/properties-dialog.go:101
-msgid "News"
-msgstr ""
-
-#: internal/widget/search-menu.go:79
-msgid "No results found"
-msgstr ""
-
-#: internal/widget/properties-dialog.go:81
-msgid "Number"
-msgstr ""
-
-#: internal/widget/shortcuts-window.ui:130
-msgid "Open bookmarks menu"
-msgstr ""
-
-#: internal/widget/context-menu.go:49 internal/widget/window-menu.go:52
-msgid "Open link"
-msgstr ""
-
-#: internal/widget/shortcuts-window.ui:15
-msgid "Open new window"
-msgstr ""
-
-#: internal/widget/shortcuts-window.ui:143
-msgid "Open properties window"
-msgstr ""
-
-#: internal/widget/shortcuts-window.ui:163
-msgid "Open shortcuts window"
-msgstr ""
-
-#: internal/widget/shortcuts-window.ui:29
-msgid "Open window menu"
-msgstr ""
-
-#: internal/widget/context-menu.go:51 internal/widget/properties-dialog.go:46
-#: internal/widget/window-menu.go:54 internal/widget/shortcuts-window.ui:139
-msgid "Properties"
-msgstr ""
-
-#: data/com.github.rkoesters.xkcd-gtk.appdata.xml.in:21
-msgid "Quickly access comic explainations via the explain xkcd wiki"
-msgstr ""
-
-#: internal/widget/app-menu.ui:50
-msgid "Quit"
-msgstr ""
-
-#: internal/widget/shortcuts-window.ui:170
-msgid "Quit application"
-msgstr ""
-
-#: data/com.github.rkoesters.xkcd-gtk.desktop.in:7
-#: data/com.github.rkoesters.xkcd-gtk.appdata.xml.in:11
-msgid "Read xkcd: a webcomic of romance, sarcasm, math, and language"
-msgstr ""
-
-#: internal/widget/bookmarks-menu.go:154
-msgid "Remove from bookmarks"
-msgstr ""
-
-#: internal/widget/zoom-box.go:51 internal/widget/shortcuts-window.ui:110
-msgid "Reset zoom"
-msgstr ""
-
-#: internal/widget/shortcuts-window.ui:79
-msgid "Search"
-msgstr ""
-
-#: internal/widget/search-menu.go:40 internal/widget/shortcuts-window.ui:83
-msgid "Search comics"
 msgstr ""
 
 #: data/com.github.rkoesters.xkcd-gtk.appdata.xml.in:16
 msgid "Search for comics"
 msgstr ""
 
-#: internal/widget/properties-dialog.go:85
-msgid "Title"
+#: data/com.github.rkoesters.xkcd-gtk.appdata.xml.in:17
+msgid "Keep track of comics with bookmarks"
 msgstr ""
 
-#: internal/widget/dark-mode-switch.go:42 internal/widget/app-menu.ui:18
-#: internal/widget/shortcuts-window.ui:156
-msgid "Toggle dark mode"
+#: data/com.github.rkoesters.xkcd-gtk.appdata.xml.in:18
+msgid "Cache comics for later offline viewing"
 msgstr ""
 
-#: internal/widget/properties-dialog.go:109
-msgid "Transcript"
-msgstr ""
-
-#: internal/widget/search-menu.go:66
-msgid "Updating comic search index..."
+#: data/com.github.rkoesters.xkcd-gtk.appdata.xml.in:19
+msgid "Dark mode for late night reading"
 msgstr ""
 
 #: data/com.github.rkoesters.xkcd-gtk.appdata.xml.in:20
 msgid "View comic metadata"
 msgstr ""
 
-#: internal/widget/window-menu.go:85 internal/widget/app-menu.ui:24
-msgid "What If?"
+#: data/com.github.rkoesters.xkcd-gtk.appdata.xml.in:21
+msgid "Quickly access comic explainations via the explain xkcd wiki"
 msgstr ""
 
-#: internal/widget/window-menu.go:29
-msgid "Window menu"
+#: data/com.github.rkoesters.xkcd-gtk.appdata.xml.in:27
+msgid "Ryan Koesters"
 msgstr ""
 
 #: data/com.github.rkoesters.xkcd-gtk.desktop.in:6
 msgid "XKCD Viewer"
 msgstr ""
 
-#: internal/widget/shortcuts-window.ui:92
-msgid "Zoom"
-msgstr ""
-
-#: internal/widget/zoom-box.go:59 internal/widget/shortcuts-window.ui:96
-msgid "Zoom in"
-msgstr ""
-
-#: internal/widget/zoom-box.go:38 internal/widget/shortcuts-window.ui:103
-msgid "Zoom out"
-msgstr ""
-
 #: data/com.github.rkoesters.xkcd-gtk.desktop.in:15
 msgid "webcomic;romance;sarcasm;math;language;"
 msgstr ""
 
-#: internal/widget/window-menu.go:86 internal/widget/app-menu.ui:28
+#: data/com.github.rkoesters.xkcd-gtk.desktop.in:19
+#: internal/widget/app-menu.ui:6
+msgid "New window"
+msgstr ""
+
+#: data/com.github.rkoesters.xkcd-gtk.desktop.in:24
+#: internal/widget/app-menu.ui:12
+msgid "Cache manager"
+msgstr ""
+
+#: data/com.github.rkoesters.xkcd-gtk.desktop.in:29
+#: internal/widget/app-menu.ui:42 internal/widget/shortcuts-window.ui:4
+msgid "Keyboard shortcuts"
+msgstr ""
+
+#: data/com.github.rkoesters.xkcd-gtk.desktop.in:34
+#: internal/widget/app-menu.ui:46
+msgid "About"
+msgstr ""
+
+#: internal/widget/app-menu.ui:18 internal/widget/shortcuts-window.ui:156
+msgid "Toggle dark mode"
+msgstr ""
+
+#: internal/widget/app-menu.ui:24
+msgid "What If?"
+msgstr ""
+
+#: internal/widget/app-menu.ui:28
 msgid "xkcd blog"
 msgstr ""
 
-#: internal/widget/window-menu.go:87 internal/widget/app-menu.ui:32
+#: internal/widget/app-menu.ui:32
 msgid "xkcd books"
+msgstr ""
+
+#: internal/widget/app-menu.ui:36
+msgid "About xkcd"
+msgstr ""
+
+#: internal/widget/app-menu.ui:50
+msgid "Quit"
+msgstr ""
+
+#: internal/widget/shortcuts-window.ui:11
+msgid "General"
+msgstr ""
+
+#: internal/widget/shortcuts-window.ui:15
+msgid "Open new window"
+msgstr ""
+
+#: internal/widget/shortcuts-window.ui:22
+msgid "Close window"
+msgstr ""
+
+#: internal/widget/shortcuts-window.ui:29
+msgid "Open window menu"
+msgstr ""
+
+#: internal/widget/shortcuts-window.ui:38
+msgid "Navigate"
+msgstr ""
+
+#: internal/widget/shortcuts-window.ui:42
+msgid "Go to the first comic"
+msgstr ""
+
+#: internal/widget/shortcuts-window.ui:49
+msgid "Go to the previous comic"
+msgstr ""
+
+#: internal/widget/shortcuts-window.ui:56
+msgid "Go to the next comic"
+msgstr ""
+
+#: internal/widget/shortcuts-window.ui:63
+msgid "Go to the newest comic"
+msgstr ""
+
+#: internal/widget/shortcuts-window.ui:70
+msgid "Go to a random comic"
+msgstr ""
+
+#: internal/widget/shortcuts-window.ui:79
+msgid "Search"
+msgstr ""
+
+#: internal/widget/shortcuts-window.ui:83
+msgid "Search comics"
+msgstr ""
+
+#: internal/widget/shortcuts-window.ui:92
+msgid "Zoom"
+msgstr ""
+
+#: internal/widget/shortcuts-window.ui:96
+msgid "Zoom in"
+msgstr ""
+
+#: internal/widget/shortcuts-window.ui:103
+msgid "Zoom out"
+msgstr ""
+
+#: internal/widget/shortcuts-window.ui:110
+msgid "Reset zoom"
+msgstr ""
+
+#: internal/widget/shortcuts-window.ui:119
+msgid "Bookmarks"
+msgstr ""
+
+#: internal/widget/shortcuts-window.ui:123
+msgid "Bookmark this comic"
+msgstr ""
+
+#: internal/widget/shortcuts-window.ui:130
+msgid "Open bookmarks menu"
+msgstr ""
+
+#: internal/widget/shortcuts-window.ui:139
+msgid "Properties"
+msgstr ""
+
+#: internal/widget/shortcuts-window.ui:143
+msgid "Open properties window"
+msgstr ""
+
+#: internal/widget/shortcuts-window.ui:152
+msgid "Application"
+msgstr ""
+
+#: internal/widget/shortcuts-window.ui:163
+msgid "Open shortcuts window"
+msgstr ""
+
+#: internal/widget/shortcuts-window.ui:170
+msgid "Quit application"
 msgstr ""


### PR DESCRIPTION
GNOME automatically excludes release descriptions on Damned Lies (GNOME Translation Platform). It's a good practice to follow the GNOME way.

This can streamline the translation process, allowing translators to focus their efforts on more critical and user-facing aspects of the application.