### PR TITLE
Change flatpak x11 permission to fallback-x11.

### DIFF
--- a/com.github.rkoesters.xkcd-gtk.yml
+++ b/com.github.rkoesters.xkcd-gtk.yml
@@ -3,7 +3,7 @@
 app-id: com.github.rkoesters.xkcd-gtk
 
 runtime: io.elementary.Platform
-runtime-version: '7.1'
+runtime-version: '7.2'
 
 sdk: io.elementary.Sdk
 

--- a/com.github.rkoesters.xkcd-gtk.yml
+++ b/com.github.rkoesters.xkcd-gtk.yml
@@ -10,7 +10,7 @@ sdk: io.elementary.Sdk
 command: com.github.rkoesters.xkcd-gtk
 
 finish-args:
-  - '--socket=x11'
+  - '--socket=fallback-x11'
   - '--socket=wayland'
   - '--share=ipc'
   - '--share=network'

--- a/flatpak/appcenter.yml.in
+++ b/flatpak/appcenter.yml.in
@@ -3,7 +3,7 @@
 app-id: com.github.rkoesters.xkcd-gtk
 
 runtime: io.elementary.Platform
-runtime-version: '7.1'
+runtime-version: '7.2'
 
 sdk: io.elementary.Sdk
 

--- a/flatpak/appcenter.yml.in
+++ b/flatpak/appcenter.yml.in
@@ -10,7 +10,7 @@ sdk: io.elementary.Sdk
 command: com.github.rkoesters.xkcd-gtk
 
 finish-args:
-  - '--socket=x11'
+  - '--socket=fallback-x11'
   - '--socket=wayland'
   - '--share=ipc'
   - '--share=network'

--- a/flatpak/flathub.yml.in
+++ b/flatpak/flathub.yml.in
@@ -3,7 +3,7 @@
 app-id: com.github.rkoesters.xkcd-gtk
 
 runtime: org.freedesktop.Platform
-runtime-version: '22.08'
+runtime-version: '23.08'
 
 sdk: org.freedesktop.Sdk
 sdk-extensions:

--- a/flatpak/flathub.yml.in
+++ b/flatpak/flathub.yml.in
@@ -12,7 +12,7 @@ sdk-extensions:
 command: com.github.rkoesters.xkcd-gtk
 
 finish-args:
-  - '--socket=x11'
+  - '--socket=fallback-x11'
   - '--socket=wayland'
   - '--share=ipc'
   - '--share=network'


### PR DESCRIPTION
If Wayland is available, we can use that instead.

Fixes "Legacy windowing system" warning on https://flathub.org/apps/com.github.rkoesters.xkcd-gtk