### PR TITLE
Improve image dark mode inversion

### DIFF
--- a/internal/widget/image-viewer.go
+++ b/internal/widget/image-viewer.go
@@ -214,14 +214,17 @@ func rgbToHsl(r, g, b uint8) (h, s, l float64) {
 		s = (max - l) / math.Min(l, 1 - l)
 	}
 
-	if max == min {
+	switch max {
+	case min:
 		h = 0
-	} else if max == rf {
+	case rf:
 		h = 60 * math.Mod((gf - bf) / c, 6)
-	} else if max == gf {
+	case gf:
 		h = 60 * ((bf - rf) / c + 2)
-	} else {
+	case bf:
 		h = 60 * ((rf - gf) / c + 4)
+	default: 
+		h = 0
 	}
 
 	if h < 0 {

--- a/internal/widget/image-viewer.go
+++ b/internal/widget/image-viewer.go
@@ -156,9 +156,11 @@ func (iv *ImageViewer) applyDarkModeImageInversion() error {
 	rowstride := iv.unscaledPixbuf.GetRowstride()
 	nChannels := iv.unscaledPixbuf.GetNChannels()
 	log.Debugf("inverting comic image: len(pixels) = %v, colorspace = %v, alpha = %v, bitsPerSample = %v, width = %v, height = %v, rowstride = %v, nChannels = %v", len(pixels), colorspace, alpha, bitsPerSample, width, height, rowstride, nChannels)
-	for x := 0; x < width; x++ {
-		for y := 0; y < height; y++ {
-			index := (y * rowstride) + (x * nChannels)
+	
+	for y := 0; y < height; y++ {
+		rowstart := y * rowstride
+		for x := 0; x < width; x++ {
+			index := rowstart + (x * nChannels)
 			switch nChannels {
 			case 3, 4:
 				h, s, l := rgbToHsl(pixels[index], pixels[index+1], pixels[index+2])


### PR DESCRIPTION
Instead of inverting the RGB color, the color is converted to HSL and the lightness is inverted instead.
This preserves the correct hue for colors.
Additionally I changed the order of the for loops to make it more cache friendly (iterating of rows first will cause less cache misses).

main:
<img width="800" height="760" alt="Screenshot_20250913_190340" src="https://github.com/user-attachments/assets/822547f1-6750-4626-9239-853cc40a29d3" />
PR:
<img width="800" height="760" alt="Screenshot_20250913_190419" src="https://github.com/user-attachments/assets/d5fb3e76-8a23-4e27-8a61-bfd596a4de6f" />
original (non-inverted):
<img width="800" height="760" alt="Screenshot_20250913_190506" src="https://github.com/user-attachments/assets/d45c1e55-8a71-419c-ba5a-7d50359d5d7c" />
