### PR TITLE
Add https://jj-vcs.github.io/ support to tool/app-version.sh.

### DIFF
--- a/tools/app-version.sh
+++ b/tools/app-version.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 set -eu -o pipefail
 
+version_from_jj () {
+  jj root >/dev/null || return 1
+  tag=$(jj log -r "latest(tags())" --no-graph -T 'tags')
+  count=$(jj log -r "latest(tags())::@ ~ empty()" --no-graph -T 'commit_id ++ "\n"' | wc -l)
+  id=$(jj log -r "latest(@-::@ ~ empty())" --no-graph -T 'commit_id.short(8)')
+  printf '%s-%s-j%s\n' "${tag:?}" "${count:?}" "${id:?}"
+}
+
 version_from_git () {
   git describe --tags --match='v[0-9].[0-9]*.[0-9]*' --dirty
 }
@@ -22,6 +30,7 @@ version_from_ci () {
   printf 'ci-%s-%s\n' "${GITHUB_REF_NAME:-nullref}" "${GITHUB_SHA:-nullsha}"
 }
 
+version_from_jj 2>/dev/null ||
 version_from_git 2>/dev/null ||
 version_from_ci 2>/dev/null ||
 version_from_text_file 2>/dev/null ||


### PR DESCRIPTION
Using a bunch of `jj log` commands to mimic `git describe --tags` but with a 'j' prefix before the commit hash instead of git's 'g' prefix.