### PR TITLE
Adjust Github Actions CI triggers.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ name: CI
   push:
     branches-ignore:
       - 'dependabot/**'
+      - 'push-[k-z]+'
   schedule:
     - cron: '29 4 1 * *'
 


### PR DESCRIPTION
Avoid running when push is created by `jj git push -c`.