### PR TITLE
Split scheduled CI workflow into separate workflow.

### DIFF
--- a/.github/workflows/ci-cron.yml
+++ b/.github/workflows/ci-cron.yml
@@ -1,15 +1,10 @@
 ---
 
-name: CI
+name: CI (cron)
 
 'on':
-  pull_request:
-    branches:
-      - main
-  push:
-    branches:
-      - main
-      - v[0-9]+.[0-9]+.[0-9]+
+  schedule:
+    - cron: 0 0 * * 6
 
 permissions:
   contents: read


### PR DESCRIPTION
GitHub will fully disable workflows with a schedule if the repo does not get activity in 60 days. The interferes with dependabot pull requests. Separating these triggers into separate workflows should fix it.